### PR TITLE
fix: resolve all five high-priority issues

### DIFF
--- a/app/helpers/decorator_helper.py
+++ b/app/helpers/decorator_helper.py
@@ -32,7 +32,7 @@ class DecoratorHelper:
     def check_first_login(f):
         @wraps(f)
         def decorated(*args, **kwargs):
-            if session["on_login"] == 1:
+            if session.get("on_login") == 1:
                 flash("Please change your password first!", "danger")
                 return redirect(url_for("admin.admin"))
             return f(*args, **kwargs)

--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -51,13 +51,12 @@ def create_admin_account():
     first_name = request.form.get("first_name")
     last_name = request.form.get("last_name")
     username = request.form.get("username")
-    password = request.form.get("password")
     email = request.form.get("email")
     role = request.form.get("role")
 
-    if admin_service.create_admin(first_name, last_name, username, password, email, role):
+    if admin_service.create_admin(first_name, last_name, username, email, role):
         flash("Admin created succesfully!", "success")
-        email_service.send_welcome_email(username, password, first_name, email)
+        email_service.send_welcome_email(username, first_name, email)
     else:
         flash("Failed to create admin account. Please check logs for more details", "danger")
     return redirect(url_for("admin.admin_panel", active_tab="admins"))
@@ -207,7 +206,7 @@ def edit_admin_account():
     email = request.form.get("email")
     role = request.form.get("role")
 
-    if user_id == session["user_id"]:
+    if int(user_id) == session["user_id"]:
         flash("You cannot edit your own account from here. Please use the profile page.", "danger")
         return redirect(url_for("admin.admin_panel", active_tab="profile"))
 
@@ -227,7 +226,7 @@ def delete_admin_account():
         return {"success": False, "message": "You do not have permission to delete admin accounts"}
     
     user_id = request.form.get("user_id")
-    if user_id == session["user_id"]:
+    if int(user_id) == session["user_id"]:
         return {"success": False, "message": "You cannot delete your own account"}
 
     if admin_service.delete_admin(user_id):

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1,4 +1,5 @@
 import bcrypt
+import secrets
 from flask import session, flash
 from factories import get_logger
 from helpers import UtilityHelper
@@ -9,12 +10,10 @@ class AdminService:
         self.logger = get_logger("admin_service")
         self.logger.info("AdminService initialized.")
     
-    def create_admin(self, first_name, last_name, username, password, email, role) -> bool:
-        if not UtilityHelper.check_password_complexity(password):
-            return False
-        password = password.encode('utf-8')
+    def create_admin(self, first_name, last_name, username, email, role) -> bool:
+        random_password = secrets.token_urlsafe(32).encode('utf-8')
         salt = bcrypt.gensalt()
-        hashed_password = bcrypt.hashpw(password, salt).decode("utf-8")
+        hashed_password = bcrypt.hashpw(random_password, salt).decode("utf-8")
         result = self.db.execute_query(f"""
                               insert into admins
                             (first_name, last_name, username, password, email, role)

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -51,11 +51,25 @@ class EmailService:
         self.logger.info(f"Succesfully sent email alert to: {self.app.config["MAIL_DEFAULT_RECIP"]}, {session["Email"]}")
         return True
     
-    def send_welcome_email(self, username, password, first_name, email) -> bool:
+    def send_welcome_email(self, username, first_name, email) -> bool:
+        auth_service = self.app.auth_service
+        row = self.db.execute_query("select id from admins where username=%s", (username,), fetch_one=True)
+        if not row:
+            self.logger.error(f"Could not find admin {username} to send welcome email.")
+            return False
+        user_id = row[0]
+        url, token = auth_service.gen_random_forgot_password_link()
+        result = self.db.execute_query(
+            "insert into admin_forgot_password (user_id, token, expire_after) values (%s, %s, now() + interval '24 hours')",
+            (user_id, token)
+        )
+        if not result:
+            self.logger.error(f"Could not insert setup token for new admin {username}.")
+            return False
         html_body = render_template('email/admin_welcome.html',
                                     username=username,
-                                    password=password,
-                                    first_name=first_name)
+                                    first_name=first_name,
+                                    url=url)
         msg = Message(subject="Welcome to IDPortal!",
                     recipients=[email],
                     html=html_body)

--- a/app/services/ldap_service.py
+++ b/app/services/ldap_service.py
@@ -32,11 +32,12 @@ class LDAPService:
             self.logger.exception("An LDAP error as occured while searching for a user!")
             return None, False
         
+        if not results:
+            return None, {}
+        dn, entry = results[0]
         attrs = {}
-        if results:
-            dn, entry = results[0]
-            for display_name, ldap_key in self.ldap_attributes.items():
-                attrs[display_name] = entry.get(ldap_key, [None])[0].decode()
+        for display_name, ldap_key in self.ldap_attributes.items():
+            attrs[display_name] = entry.get(ldap_key, [None])[0].decode()
         return dn, attrs
 
     def auth_user(self, email, password) -> bool:

--- a/app/static/js/admin_panel.js
+++ b/app/static/js/admin_panel.js
@@ -1,5 +1,11 @@
 const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.appendChild(document.createTextNode(String(str)));
+  return div.innerHTML;
+}
+
 function showResultModal(success, message, errors = {}) {
   const modalTitle = document.getElementById('resultModalTitle');
   const modalBody = document.getElementById('resultModalBody');
@@ -12,12 +18,12 @@ function showResultModal(success, message, errors = {}) {
 
   // Update modal title and message
   modalTitle.textContent = success ? "Success" : "Error";
-  modalBody.innerHTML = message;
+  modalBody.textContent = message;
 
   // Update modal errors if any
   if (Object.keys(errors).length > 0) {
     const errorList = Object.entries(errors)
-      .map(([id, error]) => `<li>Request ID ${id}: ${error}</li>`)
+      .map(([id, error]) => `<li>Request ID ${escapeHtml(id)}: ${escapeHtml(error)}</li>`)
       .join('');
     modalErrors.innerHTML = `<ul>${errorList}</ul>`;
   } else {
@@ -222,11 +228,11 @@ document.addEventListener('DOMContentLoaded', function () {
         photoModalBody.innerHTML = `
             <div class="mb-3 text-center">
                 <div class="fw-bold mb-1">User Photo</div>
-                <img src="${userPhotoUrl}" alt="User Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
+                <img src="${escapeHtml(userPhotoUrl)}" alt="User Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
             </div>
             <div class="text-center">
                 <div class="fw-bold mb-1">Driver's License</div>
-                <img src="${licensePhotoUrl}" alt="License Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
+                <img src="${escapeHtml(licensePhotoUrl)}" alt="License Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
             </div>
         `;
     });
@@ -344,6 +350,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Populate the modal body with a form
     createAdminModalBody.innerHTML = `
       <form id="createAdminForm" method="POST" action="/create_admin_account">
+        <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
         <div class="mb-3">
           <label for="firstName" class="form-label">First Name</label>
           <input type="text" class="form-control" id="firstName" name="first_name" required>
@@ -359,10 +366,6 @@ document.addEventListener('DOMContentLoaded', function () {
         <div class="mb-3">
           <label for="email" class="form-label">Email</label>
           <input type="email" class="form-control" id="email" name="email" required>
-        </div>
-        <div class="mb-3">
-          <label for="password" class="form-label">Password</label>
-          <input type="password" class="form-control" id="password" name="password" required>
         </div>
         <div class="mb-3">
           <label for="role" class="form-label">Role</label>
@@ -401,22 +404,23 @@ document.addEventListener('DOMContentLoaded', function () {
       // Populate the modal body with a form
       editAdminModalBody.innerHTML = `
         <form id="createAdminForm" method="POST" action="/edit_admin_account">
-          <input type="hidden" name="user_id" value="${admin.id}">
+          <input type="hidden" name="user_id" value="${escapeHtml(admin.id)}">
+          <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
           <div class="mb-3">
         <label for="firstName" class="form-label">First Name</label>
-        <input type="text" class="form-control" id="firstName" name="first_name" value="${firstName}" required>
+        <input type="text" class="form-control" id="firstName" name="first_name" value="${escapeHtml(firstName)}" required>
           </div>
           <div class="mb-3">
         <label for="lastName" class="form-label">Last Name</label>
-        <input type="text" class="form-control" id="lastName" name="last_name" value="${lastName}" required>
+        <input type="text" class="form-control" id="lastName" name="last_name" value="${escapeHtml(lastName)}" required>
           </div>
           <div class="mb-3">
         <label for="username" class="form-label">Username</label>
-        <input type="text" class="form-control" id="username" name="username" value="${admin.username}" required>
+        <input type="text" class="form-control" id="username" name="username" value="${escapeHtml(admin.username)}" required>
           </div>
           <div class="mb-3">
         <label for="email" class="form-label">Email</label>
-        <input type="email" class="form-control" id="email" name="email" value="${admin.email}" required>
+        <input type="email" class="form-control" id="email" name="email" value="${escapeHtml(admin.email)}" required>
           </div>
           <div class="mb-3">
         <label for="role" class="form-label">Role</label>
@@ -452,8 +456,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Populate the modal body with confirmation message and confirm button
       deleteAdminModalBody.innerHTML = `
-        <p>Are you sure you want to delete admin <strong>${admin.full_name || admin.username}</strong>?</p>
-        <input type="hidden" id="deleteAdminUserId" value="${admin.id}">
+        <p>Are you sure you want to delete admin <strong>${escapeHtml(admin.full_name || admin.username)}</strong>?</p>
+        <input type="hidden" id="deleteAdminUserId" value="${escapeHtml(admin.id)}">
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">No</button>
           <button type="button" class="btn btn-danger" id="confirmDeleteAdminBtn">Yes, Delete</button>
@@ -511,7 +515,7 @@ document.addEventListener('DOMContentLoaded', function () {
         deleteSubmissionModalBody.innerHTML = `
           <form id="deleteSubmission">
             <div class="mb-3">
-              <p>Are you sure you would like to delete this submission for <b>${name}</b>?</p>
+              <p>Are you sure you would like to delete this submission for <b>${escapeHtml(name)}</b>?</p>
             </div>
           </form>
         `;

--- a/app/templates/email/admin_welcome.html
+++ b/app/templates/email/admin_welcome.html
@@ -25,15 +25,13 @@
       <td class="content">
         <h1>Hello {{ first_name }},</h1>
         <p>You have been given access to the IDPortal admin panel!</p>
-        <p>You can log in with the following information:</p>
+        <p>Click the button below to set your password and activate your account. This link expires in <b>24 hours</b>.</p>
         <p><b>Username: {{ username }}</b></p>
-        <p><b>Password: {{ password }}</b></p>
-        <p style="color: red;">You will be required to change you password upon login.</p>
         <p style="text-align:center;">
-          <a href="{{ REVIEW_REQUEST_URL }}" class="btn">Log Into Portal</a>
+          <a href="{{ url }}" class="btn">Set Your Password</a>
         </p>
         <p>If the button above doesn’t work, copy and paste this link into your browser:</p>
-        <p><a href="{{ REVIEW_REQUEST_URL }}">{{ REVIEW_REQUEST_URL }}</a></p>
+        <p><a href="{{ url }}">{{ url }}</a></p>
         <p>Thank you,<br>{{ COMPANY_EMAIL_SIGNATURE }}</p>
       </td>
     </tr>


### PR DESCRIPTION
## Summary

- **#5 — Self-edit/delete guard bypassed**: `request.form.get("user_id")` returns a `str` but `session["user_id"]` is an `int`, so the equality check always returned `False`. Both guards now cast to `int` before comparing.
- **#6 — Stored XSS via `innerHTML`**: Added `escapeHtml()` helper (uses `createTextNode` — no regex). Applied to all user-supplied values injected into innerHTML template strings: admin names, usernames, emails, photo URLs, submission names, and error IDs. Result modal message switched to `textContent`. JS-built forms that POST directly (create admin, edit admin) now also include the CSRF token.
- **#7 — Plaintext password in welcome email**: `create_admin` now generates a random 32-byte internal password via `secrets.token_urlsafe` (never exposed). `send_welcome_email` generates a 24-hour setup token using the existing `admin_forgot_password` infrastructure and emails a one-time "Set Your Password" link. Password field removed from the create-admin modal.
- **#8 — `KeyError` in `check_first_login`**: `session["on_login"]` changed to `session.get("on_login")` so a missing key returns `None` instead of raising.
- **#9 — `UnboundLocalError` in `search_user`**: Added an early return when LDAP results are empty, so `dn` is never referenced before assignment when a user doesn't exist in the directory.

## Files Changed

| File | Changes |
|------|---------|
| `app/helpers/decorator_helper.py` | `session.get()` instead of direct key access |
| `app/routes/admin_routes.py` | `int()` cast on user_id guards; remove password from create admin call |
| `app/services/admin_service.py` | Remove password param; generate random password internally |
| `app/services/email_service.py` | Rewrite `send_welcome_email` to use setup token |
| `app/services/ldap_service.py` | Early return on empty LDAP results |
| `app/static/js/admin_panel.js` | `escapeHtml()` helper + applied throughout; CSRF in JS forms |
| `app/templates/email/admin_welcome.html` | Replace password display with setup link |

## Test Plan

- [ ] Create a new admin account — confirm welcome email arrives in MailHog with a setup link (no password)
- [ ] Click the setup link — confirm it lands on the change password page and works
- [ ] Confirm setup link expires after 24 hours (or test with a manually expired token in the DB)
- [ ] Try to edit/delete your own admin account — confirm the guard now correctly blocks it
- [ ] Log in with an email that doesn't exist in LDAP — confirm a clean failure with no 500 error
- [ ] Set a username/name with `<script>alert(1)</script>` via edit admin — confirm it renders as text in all modals, not executed
- [ ] Trigger a failed approve/reject to confirm error IDs render as text

🤖 Generated with [Claude Code](https://claude.com/claude-code)