### PR TITLE
fix: session security, security headers, CSP, and HTTPS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,15 @@
 import os
+from datetime import timedelta
 
 class BaseConfig:
     #BASE FLASK CONFIG
-    SECRET_KEY              = os.getenv("SECRET_KEY")
-    UPLOAD_FOLDER           = os.getenv("UPLOAD_FOLDER")
+    SECRET_KEY                  = os.getenv("SECRET_KEY")
+    UPLOAD_FOLDER               = os.getenv("UPLOAD_FOLDER")
+
+    # Session security
+    SESSION_COOKIE_HTTPONLY     = True
+    SESSION_COOKIE_SAMESITE     = 'Lax'
+    PERMANENT_SESSION_LIFETIME  = timedelta(hours=8)
     
     #LDAP CONFIGURATION
     LDAP_URI                = os.getenv("LDAP_URI")
@@ -47,6 +53,8 @@ class BaseConfig:
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
+    SESSION_COOKIE_SECURE = False
 
 class ProductionConfig(BaseConfig):
     DEBUG = False
+    SESSION_COOKIE_SECURE = True

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -28,6 +28,7 @@ class AuthService:
                 self.check_bfa(username, request.remote_addr, True)
                 return False
             session.clear()
+            session.permanent = True
             session["first_name"] = row[0]
             session["last_name"] = row[1]
             session["admin_username"] = row[2]
@@ -100,6 +101,7 @@ class AuthService:
     def set_session_attrs(self, attrs) -> bool:
         try:
             session.clear()
+            session.permanent = True
             for k, v in attrs.items():
                 session[k] = v
             session["user_logged_in"] = True

--- a/app/static/js/admin_panel.js
+++ b/app/static/js/admin_panel.js
@@ -1,4 +1,9 @@
 const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+const _cfg = JSON.parse(document.getElementById('app-config').textContent);
+const batchEditUrl = _cfg.batchEditUrl;
+const approveUrl   = _cfg.approveUrl;
+const rejectUrl    = _cfg.rejectUrl;
+const deleteUrl    = _cfg.deleteUrl;
 
 function escapeHtml(str) {
   const div = document.createElement('div');

--- a/app/templates/admin_panel.html
+++ b/app/templates/admin_panel.html
@@ -325,12 +325,13 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-  const batchEditUrl = "{{ url_for('admin.batch_edit') }}"; // Backend endpoint for batch editing
-  const approveUrl = "{{ url_for('admin.approve_submission') }}"; // Backend endpoint for approving submissions
-  const rejectUrl = "{{ url_for('admin.reject_submission') }}"; // Backend endpoint for rejecting submissions
-  const deleteUrl = "{{ url_for('admin.delete_submission') }}"
-  
+<script id="app-config" type="application/json">
+  {
+    "batchEditUrl": "{{ url_for('admin.batch_edit') }}",
+    "approveUrl":   "{{ url_for('admin.approve_submission') }}",
+    "rejectUrl":    "{{ url_for('admin.reject_submission') }}",
+    "deleteUrl":    "{{ url_for('admin.delete_submission') }}"
+  }
 </script>
 <script src="{{ url_for('static', filename='js/admin_panel.js') }}"></script>
 {% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:z
+      # For HTTPS: swap nginx.conf for nginx.ssl.conf and place cert.pem/key.pem in docker/nginx/certs/
+      - ./docker/nginx/nginx.ssl.conf:/etc/nginx/conf.d/default.conf:z
       - ./docker/nginx/certs:/etc/nginx/certs:z
     depends_on:
       - flask

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -4,6 +4,12 @@ server {
 
     client_max_body_size 20M;
 
+    add_header X-Frame-Options           "DENY"                              always;
+    add_header X-Content-Type-Options    "nosniff"                           always;
+    add_header X-XSS-Protection          "1; mode=block"                     always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin"   always;
+    add_header Content-Security-Policy   "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'none';" always;
+
     location / {
         proxy_pass http://flask:5000;
         proxy_set_header Host $host;
@@ -11,6 +17,4 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
-    # Optional: redirect to HTTPS
 }

--- a/docker/nginx/nginx.ssl.conf
+++ b/docker/nginx/nginx.ssl.conf
@@ -1,15 +1,27 @@
 server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
     listen 443 ssl;
     server_name _;
 
-    ssl_certificate     /etc/nginx/certs/cert.pem;
-    ssl_certificate_key /etc/nginx/certs/key.pem;
+    ssl_certificate      /etc/nginx/certs/cert.pem;
+    ssl_certificate_key  /etc/nginx/certs/key.pem;
+    ssl_protocols        TLSv1.2 TLSv1.3;
+    ssl_ciphers          HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
 
-    # Optional: Stronger TLS settings
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers HIGH:!aNULL:!MD5;
+    client_max_body_size 20M;
 
-    client_max_body_size 10M;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Frame-Options           "DENY"                              always;
+    add_header X-Content-Type-Options    "nosniff"                           always;
+    add_header X-XSS-Protection          "1; mode=block"                     always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin"   always;
+    add_header Content-Security-Policy   "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'none';" always;
 
     location / {
         proxy_pass http://flask:5000;


### PR DESCRIPTION
## Summary

- **#1 — Session cookie flags**: Added `SESSION_COOKIE_HTTPONLY=True`, `SESSION_COOKIE_SAMESITE='Lax'`, and `PERMANENT_SESSION_LIFETIME=8h` to `BaseConfig`. `SESSION_COOKIE_SECURE=True` in `ProductionConfig` only — dev stays on HTTP without breaking.
- **#2 — Session fixation**: Added `session.permanent = True` immediately after `session.clear()` in both `admin_login` and `set_session_attrs`. Flask's signed cookie architecture means clearing and repopulating the session fully rotates the cookie value. Setting `permanent=True` also enforces the 8-hour lifetime from #1.
- **#3 — Security headers + CSP**: Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection`, `Referrer-Policy`, and `Content-Security-Policy` to `nginx.conf`. The CSP restricts scripts to `'self'` and `cdn.jsdelivr.net` (Bootstrap + Cropper.js) with no `unsafe-inline`. To achieve this, the inline `<script>` block in `admin_panel.html` was replaced with a `<script type="application/json" id="app-config">` block (not executed by the browser), and `admin_panel.js` now reads the URL config from that JSON block.
- **#4 — HTTPS**: `nginx.ssl.conf` now has a proper HTTP→HTTPS redirect server block, HSTS (`max-age=63072000; includeSubDomains; preload`), all the same security headers, `ssl_prefer_server_ciphers on`, and the corrected `client_max_body_size 20M`. `docker-compose.yml` production nginx now mounts `nginx.ssl.conf` by default — place `cert.pem` and `key.pem` in `docker/nginx/certs/` to activate HTTPS.

## ⚠️ Production deployment notes

- **HTTPS**: Add your TLS certificate and key to `docker/nginx/certs/cert.pem` and `docker/nginx/certs/key.pem`. The `docker-compose.yml` production stack now uses `nginx.ssl.conf` by default.
- **Dev environment**: The `dev/docker-compose.yml` still mounts `nginx.conf` (HTTP only) — no change needed there.
- **`SESSION_COOKIE_SECURE`**: Only `True` in `ProductionConfig`. Ensure `FLASK_ENV` is not set to `development` in production.

## Test Plan

- [ ] Log in as admin — confirm session cookie has `HttpOnly` and `SameSite=Lax` flags in browser dev tools
- [ ] Log in as user (LDAP) — same check
- [ ] Load admin panel — confirm no CSP violations in browser console
- [ ] Load upload page — confirm Cropper.js loads and image preview works (blob: URLs allowed)
- [ ] Approve/reject/delete a submission via the admin panel AJAX buttons — confirm they still work with the new URL config sourced from JSON block
- [ ] In production with SSL certs: confirm HTTP redirects to HTTPS; confirm HSTS header present

🤖 Generated with [Claude Code](https://claude.com/claude-code)