### PR TITLE
feat: Microsoft Entra OAuth login for admins and end users

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,7 +3,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from dotenv import load_dotenv
 from datetime import timedelta
 from services import Database, AdminService, EmailService, LDAPService, SubmissionService, AuthService
-from routes import admin_blueprint, user_blueprint
+from routes import admin_blueprint, user_blueprint, auth_blueprint, init_oauth
 from helpers import generate_csrf_token, validate_csrf
 import os
 
@@ -79,6 +79,11 @@ def create_app():
     app.config["COMPANY_CURRENT_YEAR"]    = os.environ.get("COMPANY_CURRENT_YEAR")
     app.config["COMPANY_EMAIL_SIGNATURE"] = os.environ.get("COMPANY_EMAIL_SIGNATURE")
 
+    # ── Entra OAuth (optional — leave unset to disable Microsoft sign-in) ────
+    app.config["ENTRA_CLIENT_ID"]     = os.environ.get("ENTRA_CLIENT_ID")
+    app.config["ENTRA_CLIENT_SECRET"] = os.environ.get("ENTRA_CLIENT_SECRET")
+    app.config["ENTRA_TENANT_ID"]     = os.environ.get("ENTRA_TENANT_ID")
+
     # ── Instance config overrides (dev/instance/config.py in development) ─────
     app.config.from_pyfile("config.py", silent=True)
 
@@ -87,10 +92,13 @@ def create_app():
 
     app.register_blueprint(admin_blueprint, url_prefix="/")
     app.register_blueprint(user_blueprint, url_prefix="/")
+    app.register_blueprint(auth_blueprint, url_prefix="/")
+    init_oauth(app)
 
     @app.context_processor
     def inject():
         return {
+            "entra_enabled"           : bool(app.config.get("ENTRA_CLIENT_ID")),
             "SITE_TITLE"              : app.config["SITE_TITLE"],
             "LOGO"                    : app.config["LOGO"],
             "COMPANY_NAME"            : app.config["COMPANY_NAME"],

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
+authlib==1.3.2
 bcrypt==4.3.0
 blinker==1.9.0
 click==8.1.8
@@ -11,4 +12,5 @@ pyasn1==0.6.1
 pyasn1_modules==0.4.2
 python-dotenv==1.1.0
 python-ldap==3.4.4
+requests==2.32.3
 Werkzeug==3.1.3

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,2 +1,3 @@
 from .admin_routes import admin_blueprint
 from .user_routes import user_blueprint
+from .auth_routes import auth_blueprint, init_oauth

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, redirect, url_for, session, flash, current_app, request
+from authlib.integrations.flask_client import OAuth
+
+auth_blueprint = Blueprint('auth', __name__)
+oauth = OAuth()
+
+
+def init_oauth(app):
+    oauth.init_app(app)
+    tenant_id = app.config.get('ENTRA_TENANT_ID', '')
+    oauth.register(
+        name='entra',
+        client_id=app.config.get('ENTRA_CLIENT_ID'),
+        client_secret=app.config.get('ENTRA_CLIENT_SECRET'),
+        server_metadata_url=(
+            f'https://login.microsoftonline.com/{tenant_id}/v2.0'
+            '/.well-known/openid-configuration'
+        ),
+        client_kwargs={'scope': 'openid email profile'},
+    )
+
+
+@auth_blueprint.route('/oauth/login')
+def oauth_login():
+    if not current_app.config.get('ENTRA_CLIENT_ID'):
+        flash('Microsoft sign-in is not configured.', 'danger')
+        flow = request.args.get('flow', 'user')
+        return redirect(url_for('admin.admin') if flow == 'admin' else url_for('user.home'))
+
+    flow = request.args.get('flow', 'user')
+    session['oauth_flow'] = flow
+    redirect_uri = url_for('auth.oauth_callback', _external=True)
+    return oauth.entra.authorize_redirect(redirect_uri)
+
+
+@auth_blueprint.route('/oauth/callback')
+def oauth_callback():
+    try:
+        token = oauth.entra.authorize_access_token()
+    except Exception:
+        current_app.logger.exception('OAuth callback error')
+        flash('Sign-in failed. Please try again.', 'danger')
+        return redirect(url_for('user.home'))
+
+    userinfo = token.get('userinfo') or {}
+    flow = session.pop('oauth_flow', 'user')
+    auth_service = current_app.auth_service
+
+    if flow == 'admin':
+        if auth_service.entra_admin_login(userinfo):
+            return redirect(url_for('admin.admin_panel'))
+        return redirect(url_for('admin.admin'))
+
+    if auth_service.entra_user_login(userinfo):
+        return redirect(url_for('user.landing'))
+    return redirect(url_for('user.home'))

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -121,6 +121,50 @@ class AuthService:
             self.logger.error(f"Could not set session attributes for user: {attrs.get('Email', 'unknown')}")
             return False
         
+    def entra_admin_login(self, userinfo: dict) -> bool:
+        email = userinfo.get('email') or userinfo.get('preferred_username', '')
+        self.logger.info(f"Entra admin login attempt for: {email}")
+
+        row = self.db.execute_query(
+            """SELECT first_name, last_name, username, email, status, role, on_login, id
+               FROM admins WHERE LOWER(email) = LOWER(%s)""",
+            (email,), fetch_one=True
+        )
+        if not row:
+            self.logger.warning(f"Entra login blocked — no admin account for: {email}")
+            flash("Your account has not been provisioned. Contact a super admin.", "danger")
+            return False
+
+        if row[4] != 1:
+            self.logger.warning(f"Entra login blocked — account disabled for: {email}")
+            flash("Your account is disabled. Contact a super admin.", "danger")
+            return False
+
+        session.clear()
+        session.permanent = True
+        session["first_name"]     = row[0]
+        session["last_name"]      = row[1]
+        session["admin_username"] = row[2]
+        session["email"]          = row[3]
+        session["role"]           = row[5]
+        session["on_login"]       = 0
+        session["user_id"]        = row[7]
+        self.logger.info(f"Entra admin login successful for: {email}")
+        return True
+
+    def entra_user_login(self, userinfo: dict) -> bool:
+        email = userinfo.get('email') or userinfo.get('preferred_username', '')
+        given_name  = userinfo.get('given_name', '')
+        family_name = userinfo.get('family_name', '')
+        attrs = {
+            'First Name': given_name,
+            'Last Name':  family_name,
+            'Email':      email,
+            'cn':         userinfo.get('preferred_username', email),
+        }
+        self.logger.info(f"Entra user login for: {email}")
+        return self.set_session_attrs(attrs)
+
     def check_bfa(self, email, ip_address, failed) -> bool:
         row = self.db.execute_query("select * from bfa where email=%s", (email,), fetch_one=True)
         if row:

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -29,6 +29,17 @@
             </div>
             <button type="submit" class="btn btn-primary w-100">Log In</button>
           </form>
+
+          {% if entra_enabled %}
+          <div class="d-flex align-items-center my-3">
+            <hr class="flex-grow-1"><span class="mx-2 text-muted small">or</span><hr class="flex-grow-1">
+          </div>
+          <a href="{{ url_for('auth.oauth_login', flow='admin') }}" class="btn btn-outline-light w-100 d-flex align-items-center justify-content-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>
+            Sign in with Microsoft
+          </a>
+          {% endif %}
+
           <div class="text-center mt-3">
                 <a href="{{ url_for('admin.forgot_password') }}">Trouble signining in?</a>
             </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -28,6 +28,17 @@
             </div>
             <button type="submit" class="btn btn-primary w-100">Log In</button>
           </form>
+
+          {% if entra_enabled %}
+          <div class="d-flex align-items-center my-3">
+            <hr class="flex-grow-1"><span class="mx-2 text-muted small">or</span><hr class="flex-grow-1">
+          </div>
+          <a href="{{ url_for('auth.oauth_login', flow='user') }}" class="btn btn-outline-light w-100 d-flex align-items-center justify-content-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>
+            Sign in with Microsoft
+          </a>
+          {% endif %}
+
         </div>
       </div>
     </div>

--- a/deploy.sh
+++ b/deploy.sh
@@ -267,6 +267,14 @@ MAIL_USE_SSL=false
 MAIL_FROM_NAME=IDPortal
 MAIL_FROM_ADDRESS=CHANGE_ME
 MAIL_DEFAULT_RECIP=CHANGE_ME
+
+# ─── Microsoft Entra OAuth (optional) ────────────────────────────────────────
+# Leave blank to disable the "Sign in with Microsoft" button.
+# Register an app in Entra, add https://yourdomain/oauth/callback as a
+# redirect URI, and paste the values below.
+ENTRA_CLIENT_ID=
+ENTRA_CLIENT_SECRET=
+ENTRA_TENANT_ID=
 EOF
 
         ok "$ENV_FILE created with generated secrets"


### PR DESCRIPTION
## Summary

- Adds optional **Sign in with Microsoft** button to both the admin and end-user login pages via `authlib` and Entra OIDC
- Admins must be pre-provisioned by email in the `admins` table — unprovisioned accounts are blocked with a flash message
- End users are authenticated and their session attrs built from Entra ID token claims (`given_name`, `family_name`, `email`)
- Feature is fully disabled (buttons hidden) when `ENTRA_CLIENT_ID` is not set, so the test stack and LDAP login are unaffected

## New files

- `app/routes/auth_routes.py` — `auth_blueprint` with `/oauth/login` and `/oauth/callback` routes

## Changed files

- `app/app.py` — registers `auth_blueprint`, inits `OAuth` client, adds `ENTRA_*` config, injects `entra_enabled` into template context
- `app/services/auth_service.py` — adds `entra_admin_login()` and `entra_user_login()` methods
- `app/routes/__init__.py` — exports `auth_blueprint` and `init_oauth`
- `app/templates/admin.html` — "Sign in with Microsoft" button (gated on `entra_enabled`)
- `app/templates/login.html` — same
- `app/requirements.txt` — adds `authlib==1.3.2` and `requests==2.32.3`
- `deploy.sh` — adds `ENTRA_CLIENT_ID`, `ENTRA_CLIENT_SECRET`, `ENTRA_TENANT_ID` to the production `.env` template (blank by default)

## To activate

Register an app in Entra (single tenant), set redirect URI to `https://yourdomain/oauth/callback`, then populate the three `ENTRA_*` vars in `.env` and redeploy.

## Test plan

- [ ] With `ENTRA_*` vars unset: confirm "Sign in with Microsoft" button does not appear on either login page
- [ ] With `ENTRA_*` vars set: confirm button appears on both pages
- [ ] Admin OAuth login with a provisioned email → lands on admin panel
- [ ] Admin OAuth login with an unprovisioned email → flash error, redirected to admin login
- [ ] Admin OAuth login with a disabled account → flash error, redirected to admin login
- [ ] End user OAuth login → session set, lands on landing page
- [ ] Existing LDAP and local password login still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)