### PR TITLE
feat: add comprehensive unit test suite (181 tests)

### DIFF
--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 authlib==1.3.2
+pytest==8.3.5
 bcrypt==4.3.0
 blinker==1.9.0
 click==8.4.1

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,131 @@
+import os
+import pytest
+from unittest.mock import MagicMock
+from flask import Flask
+from routes import admin_blueprint, user_blueprint, auth_blueprint
+from helpers import generate_csrf_token
+
+
+def make_app(**overrides):
+    """Minimal Flask app with mocked services for testing."""
+    app = Flask(
+        __name__,
+        template_folder=os.path.join(os.path.dirname(__file__), '..', 'templates'),
+    )
+    app.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'test-secret-key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        'SESSION_COOKIE_SECURE': False,
+        'UPLOAD_FOLDER': '/tmp/test-uploads',
+        'ADMIN_AUTH_MODE': 'local',
+        'USER_AUTH_MODE': 'ldap',
+        'ENTRA_CLIENT_ID': None,
+        'ENTRA_CLIENT_SECRET': None,
+        'ENTRA_TENANT_ID': '',
+        'FORGOT_PASSWORD_URL': 'https://test.example.com/forgot_password',
+        'SITE_TITLE': 'Test IDPortal',
+        'LOGO': None,
+        'COMPANY_NAME': 'Test Co',
+        'COMPANY_ADDRESS': '123 Test St',
+        'COMPANY_STATE_ZIP': 'Test, TS 00000',
+        'COMPANY_PHONE': '555-0000',
+        'COMPANY_CURRENT_YEAR': '2026',
+        'COMPANY_EMAIL_SIGNATURE': 'Test IT',
+        'REVIEW_REQUEST_URL': 'https://test.example.com/admin_panel',
+        'USER_LOGIN_URL': 'https://test.example.com/login',
+        'ADMIN_URL': 'https://test.example.com/admin',
+        **overrides,
+    })
+
+    app.register_blueprint(admin_blueprint, url_prefix='/')
+    app.register_blueprint(user_blueprint, url_prefix='/')
+    app.register_blueprint(auth_blueprint, url_prefix='/')
+
+    app.db = MagicMock()
+    app.auth_service = MagicMock()
+    app.admin_service = MagicMock()
+    app.ldap_service = MagicMock()
+    app.email_service = MagicMock()
+    app.submission_service = MagicMock()
+
+    @app.context_processor
+    def _inject_csrf():
+        return {'csrf_token': generate_csrf_token}
+
+    @app.context_processor
+    def _inject_globals():
+        return {
+            'entra_enabled': bool(app.config.get('ENTRA_CLIENT_ID')),
+            'admin_auth_mode': app.config['ADMIN_AUTH_MODE'],
+            'user_auth_mode': app.config['USER_AUTH_MODE'],
+            'SITE_TITLE': app.config.get('SITE_TITLE'),
+            'LOGO': app.config.get('LOGO'),
+            'COMPANY_NAME': app.config.get('COMPANY_NAME'),
+            'COMPANY_ADDRESS': app.config.get('COMPANY_ADDRESS'),
+            'COMPANY_STATE_ZIP': app.config.get('COMPANY_STATE_ZIP'),
+            'COMPANY_PHONE': app.config.get('COMPANY_PHONE'),
+            'COMPANY_CURRENT_YEAR': app.config.get('COMPANY_CURRENT_YEAR'),
+            'COMPANY_EMAIL_SIGNATURE': app.config.get('COMPANY_EMAIL_SIGNATURE'),
+            'FORGOT_PASSWORD_URL': app.config.get('FORGOT_PASSWORD_URL'),
+            'REVIEW_REQUEST_URL': app.config.get('REVIEW_REQUEST_URL'),
+            'USER_LOGIN_URL': app.config.get('USER_LOGIN_URL'),
+        }
+
+    os.makedirs('/tmp/test-uploads', exist_ok=True)
+    return app
+
+
+@pytest.fixture
+def app():
+    return make_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['admin_username'] = 'testadmin'
+        sess['first_name'] = 'Test'
+        sess['last_name'] = 'Admin'
+        sess['email'] = 'testadmin@example.com'
+        sess['role'] = 'super'
+        sess['on_login'] = 0
+        sess['user_id'] = 1
+    return c
+
+
+@pytest.fixture
+def manager_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['admin_username'] = 'mgr'
+        sess['first_name'] = 'Manager'
+        sess['last_name'] = 'User'
+        sess['email'] = 'mgr@example.com'
+        sess['role'] = 'manager'
+        sess['on_login'] = 0
+        sess['user_id'] = 2
+    return c
+
+
+@pytest.fixture
+def user_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['user_logged_in'] = True
+        sess['attrs'] = {
+            'First Name': 'Test',
+            'Last Name': 'User',
+            'Email': 'user@example.com',
+            'ID Number': '12345',
+            'Location': 'HQ',
+            'cn': 'user@example.com',
+        }
+        for k, v in sess['attrs'].items():
+            sess[k] = v
+    return c

--- a/app/tests/test_admin_routes.py
+++ b/app/tests/test_admin_routes.py
@@ -1,0 +1,453 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tests.conftest import make_app
+
+
+@pytest.fixture
+def app():
+    return make_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['admin_username'] = 'testadmin'
+        sess['first_name'] = 'Test'
+        sess['last_name'] = 'Admin'
+        sess['email'] = 'admin@example.com'
+        sess['role'] = 'super'
+        sess['on_login'] = 0
+        sess['user_id'] = 1
+    return c
+
+
+@pytest.fixture
+def manager_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['admin_username'] = 'mgr'
+        sess['role'] = 'manager'
+        sess['on_login'] = 0
+        sess['user_id'] = 2
+        sess['first_name'] = 'M'
+        sess['last_name'] = 'G'
+        sess['email'] = 'mgr@example.com'
+    return c
+
+
+# ── GET /admin ────────────────────────────────────────────────────────────────
+
+def test_get_admin_renders_login(client):
+    with patch('routes.admin_routes.render_template', return_value='') as mock_rt:
+        resp = client.get('/admin')
+    assert resp.status_code == 200
+    mock_rt.assert_called_once_with('admin.html')
+
+
+# ── POST /admin (local auth) ──────────────────────────────────────────────────
+
+def test_post_admin_login_success(app, client):
+    app.auth_service.admin_login.return_value = True
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess['on_login'] = 0
+        with patch('routes.admin_routes.session', dict(on_login=0)):
+            resp = client.post('/admin', data={'username': 'admin', 'password': 'pass'})
+    assert resp.status_code == 302
+    assert '/admin_panel' in resp.headers['Location']
+
+
+def test_post_admin_login_failure(app, client):
+    app.auth_service.admin_login.return_value = False
+    resp = client.post('/admin', data={'username': 'admin', 'password': 'wrong'})
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_post_admin_login_blocked_in_entra_mode(app, client):
+    app.config['ADMIN_AUTH_MODE'] = 'entra'
+    resp = client.post('/admin', data={'username': 'admin', 'password': 'pass'})
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+
+
+def test_post_admin_login_first_login_redirect(app, client):
+    app.auth_service.admin_login.return_value = True
+    with patch('routes.admin_routes.session', {'on_login': 1}):
+        resp = client.post('/admin', data={'username': 'admin', 'password': 'pass'})
+    assert resp.status_code == 302
+
+
+# ── GET /admin_panel ──────────────────────────────────────────────────────────
+
+def test_get_admin_panel_unauthenticated(client):
+    resp = client.get('/admin_panel')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_get_admin_panel_authenticated(app, admin_client):
+    app.admin_service.populate_admin_panel.return_value = {
+        'pending_requests': [],
+        'pending_pagination': {'total_pages': 1, 'next_page': None, 'prev_page': None},
+    }
+    with patch('routes.admin_routes.render_template', return_value=''):
+        resp = admin_client.get('/admin_panel?active_tab=pending')
+    assert resp.status_code == 200
+
+
+def test_get_admin_panel_search(app, admin_client):
+    app.submission_service.search.return_value = {
+        'search_results': [{'request_id': 1}],
+        'search_pagination': {'total_pages': 1, 'next_page': None, 'prev_page': None},
+    }
+    with patch('routes.admin_routes.render_template', return_value=''):
+        resp = admin_client.get('/admin_panel?search_term=alice')
+    assert resp.status_code == 200
+
+
+def test_get_admin_panel_search_no_results(app, admin_client):
+    app.submission_service.search.return_value = None
+    resp = admin_client.get('/admin_panel?search_term=nobody')
+    assert resp.status_code == 302
+
+
+# ── POST /logout ──────────────────────────────────────────────────────────────
+
+def test_logout_admin_clears_session(admin_client):
+    resp = admin_client.get('/logout')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_logout_user_redirects_home(client):
+    with client.session_transaction() as sess:
+        sess['user_logged_in'] = True
+    resp = client.get('/logout')
+    assert resp.status_code == 302
+
+
+# ── POST /reject_submission ────────────────────────────────────────────────────
+
+def test_reject_submission_success(app, admin_client):
+    app.submission_service.reject_request.return_value = True
+    resp = admin_client.post('/reject_submission',
+                             data={'request_id': '1', 'comments': 'Bad photo'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+
+
+def test_reject_submission_failure(app, admin_client):
+    app.submission_service.reject_request.return_value = False
+    resp = admin_client.post('/reject_submission',
+                             data={'request_id': '1', 'comments': ''})
+    assert resp.get_json()['success'] is False
+
+
+def test_reject_submission_comment_too_long(admin_client):
+    resp = admin_client.post('/reject_submission',
+                             data={'request_id': '1', 'comments': 'x' * 251})
+    assert resp.get_json()['success'] is False
+    assert '250' in resp.get_json()['message']
+
+
+def test_reject_submission_unauthenticated(client):
+    resp = client.post('/reject_submission',
+                       data={'request_id': '1', 'comments': ''})
+    assert resp.status_code == 302
+
+
+# ── POST /approve_submission ───────────────────────────────────────────────────
+
+def test_approve_submission_success(app, admin_client):
+    app.submission_service.approve_request.return_value = True
+    resp = admin_client.post('/approve_submission', data={'request_id': '1'})
+    assert resp.get_json()['success'] is True
+
+
+def test_approve_submission_failure(app, admin_client):
+    app.submission_service.approve_request.return_value = False
+    resp = admin_client.post('/approve_submission', data={'request_id': '1'})
+    assert resp.get_json()['success'] is False
+
+
+# ── POST /create_admin_account ────────────────────────────────────────────────
+
+def test_create_admin_local_mode_success(app, admin_client):
+    app.admin_service.create_admin.return_value = True
+    resp = admin_client.post('/create_admin_account', data={
+        'first_name': 'Bob',
+        'last_name': 'Jones',
+        'username': 'bjones',
+        'email': 'b@example.com',
+        'role': 'manager',
+    })
+    assert resp.status_code == 302
+    app.admin_service.create_admin.assert_called_once()
+
+
+def test_create_admin_local_invalid_first_name(admin_client):
+    resp = admin_client.post('/create_admin_account', data={
+        'first_name': 'B0b!',
+        'last_name': 'Jones',
+        'username': 'bjones',
+        'email': 'b@example.com',
+        'role': 'manager',
+    })
+    assert resp.status_code == 302
+
+
+def test_create_admin_invalid_email(admin_client):
+    resp = admin_client.post('/create_admin_account', data={
+        'first_name': 'Bob',
+        'last_name': 'Jones',
+        'username': 'bjones',
+        'email': 'not-an-email',
+        'role': 'manager',
+    })
+    assert resp.status_code == 302
+
+
+def test_create_admin_invalid_role(admin_client):
+    resp = admin_client.post('/create_admin_account', data={
+        'first_name': 'Bob',
+        'last_name': 'Jones',
+        'username': 'bjones',
+        'email': 'b@example.com',
+        'role': 'superadmin',
+    })
+    assert resp.status_code == 302
+
+
+def test_create_admin_entra_mode_only_needs_email_role(app, admin_client):
+    app.config['ADMIN_AUTH_MODE'] = 'entra'
+    app.admin_service.create_admin.return_value = True
+    resp = admin_client.post('/create_admin_account', data={
+        'email': 'newadmin@example.com',
+        'role': 'manager',
+    })
+    assert resp.status_code == 302
+    app.admin_service.create_admin.assert_called_once()
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+
+
+def test_create_admin_blocked_for_non_super(app, manager_client):
+    resp = manager_client.post('/create_admin_account', data={
+        'first_name': 'Bob', 'last_name': 'Jones',
+        'username': 'bjones', 'email': 'b@example.com', 'role': 'manager',
+    })
+    assert resp.status_code == 302
+    app.admin_service.create_admin.assert_not_called()
+
+
+# ── POST /edit_admin_account ───────────────────────────────────────────────────
+
+def test_edit_admin_success(app, admin_client):
+    app.admin_service.edit_admin.return_value = True
+    resp = admin_client.post('/edit_admin_account', data={
+        'user_id': '5',
+        'first_name': 'Alice',
+        'last_name': 'Smith',
+        'username': 'asmith',
+        'email': 'a@example.com',
+        'role': 'manager',
+    })
+    assert resp.status_code == 302
+
+
+def test_edit_admin_self_edit_blocked(app, admin_client):
+    # admin_client has user_id=1; trying to edit user_id=1 is blocked
+    resp = admin_client.post('/edit_admin_account', data={
+        'user_id': '1',
+        'first_name': 'Test',
+        'last_name': 'Admin',
+        'username': 'testadmin',
+        'email': 'admin@example.com',
+        'role': 'super',
+    })
+    assert resp.status_code == 302
+
+
+def test_edit_admin_blocked_for_non_super(app, manager_client):
+    resp = manager_client.post('/edit_admin_account', data={
+        'user_id': '5',
+        'first_name': 'A', 'last_name': 'B',
+        'username': 'ab', 'email': 'a@b.com', 'role': 'manager',
+    })
+    assert resp.status_code == 302
+    app.admin_service.edit_admin.assert_not_called()
+
+
+# ── POST /delete_admin_account ────────────────────────────────────────────────
+
+def test_delete_admin_success(app, admin_client):
+    app.admin_service.delete_admin.return_value = True
+    resp = admin_client.post('/delete_admin_account', data={'user_id': '5'})
+    assert resp.get_json()['success'] is True
+
+
+def test_delete_admin_self_delete_blocked(admin_client):
+    resp = admin_client.post('/delete_admin_account', data={'user_id': '1'})
+    assert resp.get_json()['success'] is False
+
+
+def test_delete_admin_blocked_for_non_super(app, manager_client):
+    resp = manager_client.post('/delete_admin_account', data={'user_id': '5'})
+    assert resp.get_json()['success'] is False
+    app.admin_service.delete_admin.assert_not_called()
+
+
+def test_delete_admin_invalid_id(admin_client):
+    resp = admin_client.post('/delete_admin_account', data={'user_id': 'abc'})
+    assert resp.get_json()['success'] is False
+
+
+# ── POST /batch_edit ──────────────────────────────────────────────────────────
+
+def test_batch_approve_success(app, admin_client):
+    app.submission_service.approve_request.return_value = True
+    resp = admin_client.post('/batch_edit',
+                             data={'action': 'approve', 'request_ids': ['1', '2', '3']})
+    assert resp.get_json()['success'] is True
+    assert app.submission_service.approve_request.call_count == 3
+
+
+def test_batch_reject_success(app, admin_client):
+    app.submission_service.reject_request.return_value = True
+    resp = admin_client.post('/batch_edit', data={
+        'action': 'reject',
+        'request_ids': ['1', '2'],
+        'comments': 'Batch reject',
+    })
+    assert resp.get_json()['success'] is True
+
+
+def test_batch_reject_comment_too_long(admin_client):
+    resp = admin_client.post('/batch_edit', data={
+        'action': 'reject',
+        'request_ids': ['1'],
+        'comments': 'x' * 251,
+    })
+    assert resp.get_json()['success'] is False
+
+
+def test_batch_approve_partial_failure(app, admin_client):
+    app.submission_service.approve_request.side_effect = [True, False, True]
+    resp = admin_client.post('/batch_edit',
+                             data={'action': 'approve', 'request_ids': ['1', '2', '3']})
+    assert resp.get_json()['success'] is False
+
+
+# ── POST /delete_submission ───────────────────────────────────────────────────
+
+def test_delete_submission_success(app, admin_client):
+    app.submission_service.delete.return_value = True
+    resp = admin_client.post('/delete_submission', data={'request_id': '10'})
+    assert resp.get_json()['success'] is True
+
+
+def test_delete_submission_failure(app, admin_client):
+    app.submission_service.delete.return_value = False
+    resp = admin_client.post('/delete_submission', data={'request_id': '10'})
+    assert resp.get_json()['success'] is False
+
+
+# ── GET /forgot_password ───────────────────────────────────────────────────────
+
+def test_get_forgot_password_renders_form(client):
+    with patch('routes.admin_routes.render_template', return_value=''):
+        resp = client.get('/forgot_password')
+    assert resp.status_code == 200
+
+
+def test_get_forgot_password_blocked_in_entra_mode(app, client):
+    app.config['ADMIN_AUTH_MODE'] = 'entra'
+    resp = client.get('/forgot_password')
+    assert resp.status_code == 302
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+
+
+def test_post_forgot_password_with_email(app, client):
+    app.email_service.send_forgot_password_email.return_value = True
+    with patch('routes.admin_routes.forgot_password_limiter') as mock_lim:
+        mock_lim.is_allowed.return_value = True
+        resp = client.post('/forgot_password', data={'identifier': 'admin@example.com'})
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_post_forgot_password_rate_limited(app, client):
+    with patch('routes.admin_routes.forgot_password_limiter') as mock_lim:
+        mock_lim.is_allowed.return_value = False
+        resp = client.post('/forgot_password', data={'identifier': 'admin@example.com'})
+    assert resp.status_code == 302
+
+
+def test_get_forgot_password_valid_token(app, client):
+    app.auth_service.validate_forgot_password_token.return_value = 'admin'
+    resp = client.get('/forgot_password?token=validtoken')
+    assert resp.status_code == 302
+    assert '/change_admin_password' in resp.headers['Location']
+
+
+def test_get_forgot_password_invalid_token(app, client):
+    app.auth_service.validate_forgot_password_token.return_value = False
+    resp = client.get('/forgot_password?token=badtoken')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+# ── GET /change_admin_password ────────────────────────────────────────────────
+
+def test_change_password_get_renders(admin_client):
+    with patch('routes.admin_routes.render_template', return_value=''):
+        resp = admin_client.get('/change_admin_password')
+    assert resp.status_code == 200
+
+
+def test_change_password_blocked_in_entra_mode(app, admin_client):
+    app.config['ADMIN_AUTH_MODE'] = 'entra'
+    resp = admin_client.get('/change_admin_password')
+    assert resp.status_code == 302
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+
+
+def test_change_password_post_success(app, admin_client):
+    app.auth_service.compare_password.return_value = True
+    app.auth_service.update_admin_password.return_value = True
+    resp = admin_client.post('/change_admin_password', data={
+        'current_password': 'OldPass1!',
+        'new_password': 'NewPass1!',
+        'confirm_password': 'NewPass1!',
+    })
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_change_password_post_passwords_mismatch(app, admin_client):
+    app.auth_service.compare_password.return_value = True
+    resp = admin_client.post('/change_admin_password', data={
+        'current_password': 'OldPass1!',
+        'new_password': 'NewPass1!',
+        'confirm_password': 'DifferentPass1!',
+    })
+    assert resp.status_code == 302
+    assert '/change_admin_password' in resp.headers['Location']
+
+
+def test_change_password_post_wrong_current(app, admin_client):
+    app.auth_service.compare_password.return_value = False
+    resp = admin_client.post('/change_admin_password', data={
+        'current_password': 'wrong',
+        'new_password': 'NewPass1!',
+        'confirm_password': 'NewPass1!',
+    })
+    assert resp.status_code == 302

--- a/app/tests/test_admin_service.py
+++ b/app/tests/test_admin_service.py
@@ -1,0 +1,152 @@
+import pytest
+from unittest.mock import MagicMock, call
+from flask import Flask, session
+from services.admin_service import AdminService
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({'TESTING': True, 'SECRET_KEY': 'admin-svc-test'})
+    return a
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(db):
+    return AdminService(db=db)
+
+
+# ── create_admin ─────────────────────────────────────────────────────────────
+
+def test_create_admin_success(svc, db):
+    db.execute_query.return_value = True
+    result = svc.create_admin("Alice", "Smith", "asmith", "a@b.com", "manager")
+    assert result is True
+    db.execute_query.assert_called_once()
+
+
+def test_create_admin_db_failure_returns_none(svc, db):
+    db.execute_query.return_value = False
+    result = svc.create_admin("Alice", "Smith", "asmith", "a@b.com", "manager")
+    # create_admin returns True on success but falls through (returns None) on failure
+    assert not result
+
+
+def test_create_admin_hashes_password(svc, db):
+    db.execute_query.return_value = True
+    svc.create_admin("A", "B", "ab", "a@b.com", "super")
+    _, kwargs = db.execute_query.call_args
+    # Not testing this via kwargs — just verify the call happened with a hashed pw
+    args = db.execute_query.call_args[0]
+    assert len(args) == 2  # SQL + params tuple
+    params = args[1]
+    assert params[0] == "A"  # first_name
+    assert params[4] == "a@b.com"  # email
+    # The hashed password should not equal the random token in plaintext
+    assert len(params[3]) > 20  # bcrypt hash is 60 chars
+
+
+# ── edit_admin ────────────────────────────────────────────────────────────────
+
+def test_edit_admin_success(svc, db):
+    db.execute_query.return_value = True
+    result = svc.edit_admin(1, "Bob", "Jones", "bjones", "b@b.com", "manager")
+    assert result is True
+
+
+def test_edit_admin_db_failure(svc, db):
+    db.execute_query.return_value = False
+    result = svc.edit_admin(1, "Bob", "Jones", "bjones", "b@b.com", "manager")
+    assert result is False
+
+
+# ── delete_admin ──────────────────────────────────────────────────────────────
+
+def test_delete_admin_success(svc, db):
+    db.execute_query.return_value = True
+    result = svc.delete_admin(5)
+    assert result is True
+    db.execute_query.assert_called_once_with("delete from admins where id=%s", (5,))
+
+
+def test_delete_admin_db_failure(svc, db):
+    db.execute_query.return_value = False
+    result = svc.delete_admin(5)
+    assert result is False
+
+
+# ── populate_admin_panel ──────────────────────────────────────────────────────
+
+def test_populate_admin_panel_pending_tab(app, svc, db):
+    db.execute_query.side_effect = [
+        (5,),    # count(*)
+        [{'full_name': 'Alice Smith', 'request_id': 1}],
+    ]
+    with app.test_request_context('/'):
+        session['role'] = 'super'
+        result = svc.populate_admin_panel(page=1, active_tab='pending')
+    assert 'pending_requests' in result
+    assert 'pending_pagination' in result
+
+
+def test_populate_admin_panel_pending_pagination(app, svc, db):
+    db.execute_query.side_effect = [
+        (45,),  # 45 total → 3 pages at 15 per page
+        [],
+    ]
+    with app.test_request_context('/'):
+        session['role'] = 'super'
+        result = svc.populate_admin_panel(page=2, active_tab='pending')
+    pag = result['pending_pagination']
+    assert pag['total_pages'] == 3
+    assert pag['prev_page'] == 1
+    assert pag['next_page'] == 3
+
+
+def test_populate_admin_panel_approved_tab(app, svc, db):
+    db.execute_query.side_effect = [(0,), []]
+    with app.test_request_context('/'):
+        session['role'] = 'manager'
+        result = svc.populate_admin_panel(page=1, active_tab='approved')
+    assert 'approved_requests' in result
+
+
+def test_populate_admin_panel_rejected_tab(app, svc, db):
+    db.execute_query.side_effect = [(0,), []]
+    with app.test_request_context('/'):
+        session['role'] = 'manager'
+        result = svc.populate_admin_panel(page=1, active_tab='rejected')
+    assert 'rejected_requests' in result
+
+
+def test_populate_admin_panel_admins_tab_super(app, svc, db):
+    db.execute_query.side_effect = [
+        (2,),  # count
+        [{'full_name': 'Admin One', 'id': 1}, {'full_name': 'Admin Two', 'id': 2}],
+    ]
+    with app.test_request_context('/'):
+        session['role'] = 'super'
+        result = svc.populate_admin_panel(page=1, active_tab='admins')
+    assert 'admins' in result
+    assert len(result['admins']) == 2
+
+
+def test_populate_admin_panel_admins_tab_non_super(app, svc, db):
+    db.execute_query.return_value = (1,)
+    with app.test_request_context('/'):
+        session['role'] = 'manager'
+        result = svc.populate_admin_panel(page=1, active_tab='admins')
+    # Managers get an empty dict for the admins tab
+    assert result == {}
+
+
+def test_populate_admin_panel_unknown_tab(app, svc, db):
+    with app.test_request_context('/'):
+        session['role'] = 'super'
+        result = svc.populate_admin_panel(page=1, active_tab='nonexistent')
+    assert result == {'none': None}

--- a/app/tests/test_auth_routes.py
+++ b/app/tests/test_auth_routes.py
@@ -1,0 +1,173 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tests.conftest import make_app
+
+
+@pytest.fixture
+def app():
+    return make_app()
+
+
+@pytest.fixture
+def app_with_entra():
+    return make_app(
+        ENTRA_CLIENT_ID='test-client-id',
+        ENTRA_CLIENT_SECRET='test-secret',
+        ENTRA_TENANT_ID='test-tenant',
+        ADMIN_AUTH_MODE='both',
+        USER_AUTH_MODE='both',
+    )
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def entra_client(app_with_entra):
+    return app_with_entra.test_client()
+
+
+# ── GET /oauth/login — no Entra config ───────────────────────────────────────
+
+def test_oauth_login_no_config_user_flow_redirects_home(client):
+    resp = client.get('/oauth/login?flow=user')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_oauth_login_no_config_admin_flow_redirects_admin(client):
+    resp = client.get('/oauth/login?flow=admin')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+# ── GET /oauth/login — auth mode enforcement ──────────────────────────────────
+
+def test_oauth_login_admin_flow_blocked_in_local_mode(app):
+    app.config['ENTRA_CLIENT_ID'] = 'some-id'
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+    c = app.test_client()
+    resp = c.get('/oauth/login?flow=admin')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+    app.config['ENTRA_CLIENT_ID'] = None
+    app.config['ADMIN_AUTH_MODE'] = 'local'
+
+
+def test_oauth_login_user_flow_blocked_in_ldap_mode(app):
+    app.config['ENTRA_CLIENT_ID'] = 'some-id'
+    app.config['USER_AUTH_MODE'] = 'ldap'
+    c = app.test_client()
+    resp = c.get('/oauth/login?flow=user')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+    app.config['ENTRA_CLIENT_ID'] = None
+    app.config['USER_AUTH_MODE'] = 'ldap'
+
+
+# ── GET /oauth/login — Entra configured ──────────────────────────────────────
+
+def test_oauth_login_with_entra_redirects_to_microsoft(app_with_entra, entra_client):
+    mock_redirect = MagicMock(return_value=('', 302, {'Location': 'https://login.microsoft.com/...'}))
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_redirect.return_value = mock_redirect()
+        resp = entra_client.get('/oauth/login?flow=user')
+    assert resp.status_code == 302
+
+
+def test_oauth_login_sets_flow_in_session(app_with_entra, entra_client):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 302
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_redirect.return_value = mock_resp
+        with entra_client.session_transaction() as sess:
+            sess.clear()
+        entra_client.get('/oauth/login?flow=admin')
+    # The route should have set oauth_flow in session before redirect
+    mock_oauth.entra.authorize_redirect.assert_called_once()
+
+
+# ── GET /oauth/callback ───────────────────────────────────────────────────────
+
+def test_oauth_callback_exception_redirects_home(app, client):
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.side_effect = Exception("auth error")
+        resp = client.get('/oauth/callback')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_oauth_callback_admin_flow_success(app, client):
+    app.auth_service.entra_admin_login.return_value = True
+    with client.session_transaction() as sess:
+        sess['oauth_flow'] = 'admin'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'email': 'admin@example.com', 'given_name': 'A', 'family_name': 'B'}
+        }
+        resp = client.get('/oauth/callback')
+    assert resp.status_code == 302
+    assert '/admin_panel' in resp.headers['Location']
+
+
+def test_oauth_callback_admin_flow_failure_redirects_admin(app, client):
+    app.auth_service.entra_admin_login.return_value = False
+    with client.session_transaction() as sess:
+        sess['oauth_flow'] = 'admin'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'email': 'unknown@example.com'}
+        }
+        resp = client.get('/oauth/callback')
+    assert resp.status_code == 302
+    assert '/admin' in resp.headers['Location']
+
+
+def test_oauth_callback_user_flow_success(app, client):
+    app.auth_service.entra_user_login.return_value = True
+    with client.session_transaction() as sess:
+        sess['oauth_flow'] = 'user'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'email': 'user@example.com'}
+        }
+        resp = client.get('/oauth/callback')
+    assert resp.status_code == 302
+    assert '/landing' in resp.headers['Location']
+
+
+def test_oauth_callback_user_flow_failure_redirects_home(app, client):
+    app.auth_service.entra_user_login.return_value = False
+    with client.session_transaction() as sess:
+        sess['oauth_flow'] = 'user'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {}
+        }
+        resp = client.get('/oauth/callback')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_oauth_callback_default_flow_is_user(app, client):
+    app.auth_service.entra_user_login.return_value = True
+    # No oauth_flow in session → defaults to 'user'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {'userinfo': {}}
+        client.get('/oauth/callback')
+    app.auth_service.entra_user_login.assert_called_once()
+    app.auth_service.entra_admin_login.assert_not_called()
+
+
+def test_oauth_callback_clears_flow_from_session(app, client):
+    app.auth_service.entra_user_login.return_value = True
+    with client.session_transaction() as sess:
+        sess['oauth_flow'] = 'user'
+    with patch('routes.auth_routes.oauth') as mock_oauth:
+        mock_oauth.entra.authorize_access_token.return_value = {'userinfo': {}}
+        client.get('/oauth/callback')
+    # Verify oauth_flow was popped (session.pop used in route)
+    with client.session_transaction() as sess:
+        assert 'oauth_flow' not in sess

--- a/app/tests/test_auth_service.py
+++ b/app/tests/test_auth_service.py
@@ -179,8 +179,13 @@ def test_set_session_attrs_sets_keys(app, svc):
     with app.test_request_context('/'):
         result = svc.set_session_attrs(attrs)
         assert session.get('First Name') == 'Alice'
-        assert session.get('user_logged_in') is True
     assert result is True
+
+
+def test_set_session_attrs_marks_user_logged_in(app, svc):
+    with app.test_request_context('/'):
+        svc.set_session_attrs({'Email': 'x@x.com'})
+        assert session.get('user_logged_in') is True
 
 
 # ── entra_admin_login ─────────────────────────────────────────────────────────

--- a/app/tests/test_auth_service.py
+++ b/app/tests/test_auth_service.py
@@ -1,0 +1,280 @@
+import bcrypt
+import pytest
+from unittest.mock import MagicMock
+from flask import Flask, session
+from services.auth_service import AuthService
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'auth-test-secret',
+        'FORGOT_PASSWORD_URL': 'https://example.com/forgot_password',
+    })
+    return a
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(db):
+    return AuthService(db=db)
+
+
+def _hash(pw: str) -> str:
+    return bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode()
+
+
+def _req_ctx(app, ip='127.0.0.1'):
+    return app.test_request_context('/', environ_base={'REMOTE_ADDR': ip})
+
+
+# ── admin_login ──────────────────────────────────────────────────────────────
+# check_bfa is called first: execute_query("select * from bfa") → None means no record
+# then the admins SELECT uses the next side_effect entry.
+
+def test_admin_login_success(app, svc, db):
+    hashed = _hash("Password1!")
+    db.execute_query.side_effect = [
+        None,  # check_bfa: no bfa record → returns True
+        ("First", "Last", "user", "u@e.com", hashed, 1, "super", 0, 42),
+    ]
+    with _req_ctx(app):
+        result = svc.admin_login("user", "Password1!")
+        assert session.get('admin_username') == 'user'
+        assert session.get('role') == 'super'
+    assert result is True
+
+
+def test_admin_login_user_not_found(app, svc, db):
+    db.execute_query.side_effect = [None, None]
+    with _req_ctx(app):
+        result = svc.admin_login("nobody", "pass")
+    assert result is False
+
+
+def test_admin_login_account_disabled(app, svc, db):
+    hashed = _hash("Password1!")
+    db.execute_query.side_effect = [
+        None,
+        ("First", "Last", "user", "u@e.com", hashed, 0, "super", 0, 1),
+    ]
+    with _req_ctx(app):
+        result = svc.admin_login("user", "Password1!")
+    assert result is False
+
+
+def test_admin_login_wrong_password(app, svc, db):
+    hashed = _hash("CorrectPass1!")
+    db.execute_query.side_effect = [
+        None,   # first check_bfa: no record → allowed
+        ("First", "Last", "user", "u@e.com", hashed, 1, "super", 0, 1),
+        None,   # second check_bfa (failed=True): no record → select
+        None,   # insert new bfa record
+    ]
+    with _req_ctx(app):
+        result = svc.admin_login("user", "WrongPass1!")
+    assert result is False
+
+
+def test_admin_login_bfa_locked(app, svc, db):
+    # BFA row exists with 3 failures → check_bfa returns False → login blocked
+    db.execute_query.side_effect = [
+        (None, None, None, 3, None),  # bfa row: row[3]=3
+        (False,),                     # is_older = False (still within 30 min)
+        ("2026-01-01 00:30:00",),     # unlock time
+    ]
+    with _req_ctx(app):
+        result = svc.admin_login("user", "Password1!")
+    assert result is False
+
+
+# ── update_admin_password ────────────────────────────────────────────────────
+
+def test_update_admin_password_success(app, svc, db):
+    old_hashed = _hash("OldPass1!")
+    db.execute_query.side_effect = [(old_hashed,), True]
+    with app.test_request_context('/'):
+        result = svc.update_admin_password("user", "NewPass1!")
+    assert result is True
+
+
+def test_update_admin_password_same_as_old(app, svc, db):
+    same = "SamePass1!"
+    db.execute_query.return_value = (_hash(same),)
+    with app.test_request_context('/'):
+        result = svc.update_admin_password("user", same)
+    assert result is False
+
+
+def test_update_admin_password_fails_complexity(app, svc, db):
+    with app.test_request_context('/'):
+        result = svc.update_admin_password("user", "weak")
+    assert result is False
+    db.execute_query.assert_not_called()
+
+
+def test_update_admin_password_user_not_found(app, svc, db):
+    db.execute_query.return_value = None
+    with app.test_request_context('/'):
+        result = svc.update_admin_password("ghost", "NewPass1!")
+    assert result is False
+
+
+# ── compare_password ─────────────────────────────────────────────────────────
+
+def test_compare_password_match(svc, db):
+    hashed = _hash("MyPass1!")
+    db.execute_query.return_value = (hashed,)
+    assert svc.compare_password("user", "MyPass1!") is True
+
+
+def test_compare_password_no_match(svc, db):
+    hashed = _hash("MyPass1!")
+    db.execute_query.return_value = (hashed,)
+    assert svc.compare_password("user", "WrongPass1!") is False
+
+
+def test_compare_password_user_not_found(svc, db):
+    db.execute_query.return_value = None
+    assert svc.compare_password("ghost", "MyPass1!") is False
+
+
+# ── token helpers ────────────────────────────────────────────────────────────
+
+def test_gen_random_forgot_password_link_format(app, svc):
+    with app.test_request_context('/'):
+        url, token = svc.gen_random_forgot_password_link()
+    assert token in url
+    assert 'forgot_password' in url
+    assert len(token) == 32
+
+
+def test_validate_forgot_password_token_valid(svc, db):
+    db.execute_query.return_value = ("someuser",)
+    result = svc.validate_forgot_password_token("abc123")
+    assert result == "someuser"
+
+
+def test_validate_forgot_password_token_invalid(svc, db):
+    db.execute_query.return_value = None
+    assert svc.validate_forgot_password_token("badtoken") is False
+
+
+def test_del_forgot_password_token(svc, db):
+    result = svc.del_forgot_password_token("sometoken")
+    assert result is True
+    db.execute_query.assert_called_once()
+
+
+# ── set_session_attrs ────────────────────────────────────────────────────────
+
+def test_set_session_attrs_sets_keys(app, svc):
+    attrs = {'First Name': 'Alice', 'Email': 'alice@example.com'}
+    with app.test_request_context('/'):
+        result = svc.set_session_attrs(attrs)
+        assert session.get('First Name') == 'Alice'
+        assert session.get('user_logged_in') is True
+    assert result is True
+
+
+# ── entra_admin_login ─────────────────────────────────────────────────────────
+
+def test_entra_admin_login_success(app, svc, db):
+    db.execute_query.side_effect = [
+        ("First", "Last", "admin", "a@b.com", 1, "super", 0, 7),
+        None,  # UPDATE name
+    ]
+    userinfo = {'email': 'a@b.com', 'given_name': 'First', 'family_name': 'Last'}
+    with app.test_request_context('/'):
+        result = svc.entra_admin_login(userinfo)
+        assert session.get('admin_username') == 'admin'
+        assert session.get('role') == 'super'
+    assert result is True
+
+
+def test_entra_admin_login_not_provisioned(app, svc, db):
+    db.execute_query.return_value = None
+    with app.test_request_context('/'):
+        result = svc.entra_admin_login({'email': 'unknown@b.com'})
+    assert result is False
+
+
+def test_entra_admin_login_account_disabled(app, svc, db):
+    db.execute_query.return_value = ("F", "L", "admin", "a@b.com", 0, "super", 0, 7)
+    with app.test_request_context('/'):
+        result = svc.entra_admin_login({'email': 'a@b.com'})
+    assert result is False
+
+
+def test_entra_admin_login_uses_preferred_username_fallback(app, svc, db):
+    db.execute_query.side_effect = [
+        ("F", "L", "admin", "a@b.com", 1, "manager", 0, 3),
+        None,
+    ]
+    userinfo = {'preferred_username': 'a@b.com', 'given_name': 'F', 'family_name': 'L'}
+    with app.test_request_context('/'):
+        result = svc.entra_admin_login(userinfo)
+    assert result is True
+
+
+# ── entra_user_login ──────────────────────────────────────────────────────────
+
+def test_entra_user_login_sets_session(app, svc):
+    userinfo = {
+        'email': 'u@example.com',
+        'given_name': 'Jane',
+        'family_name': 'Doe',
+        'preferred_username': 'u@example.com',
+    }
+    with app.test_request_context('/'):
+        result = svc.entra_user_login(userinfo)
+        assert session.get('user_logged_in') is True
+    assert result is True
+
+
+# ── check_bfa ────────────────────────────────────────────────────────────────
+
+def test_check_bfa_no_record_success_allowed(svc, db):
+    db.execute_query.return_value = None
+    assert svc.check_bfa("user@x.com", "1.2.3.4", False) is True
+
+
+def test_check_bfa_no_record_failed_inserts_row(svc, db):
+    db.execute_query.return_value = None
+    svc.check_bfa("user@x.com", "1.2.3.4", True)
+    assert db.execute_query.call_count == 2  # select + insert
+
+
+def test_check_bfa_under_limit_failed_increments(svc, db):
+    db.execute_query.side_effect = [
+        (None, None, None, 2),  # existing row with 2 failures
+        None,                   # update
+    ]
+    result = svc.check_bfa("user@x.com", "1.2.3.4", True)
+    assert result is True
+
+
+def test_check_bfa_at_limit_within_30min_blocked(svc, db):
+    db.execute_query.side_effect = [
+        (None, None, None, 3),  # 3 failures
+        (False,),               # not older than 30 min → still locked
+        ("2026-01-01 00:30:00",),
+    ]
+    result = svc.check_bfa("user@x.com", "1.2.3.4", False)
+    assert result is False
+
+
+def test_check_bfa_at_limit_after_30min_resets(svc, db):
+    db.execute_query.side_effect = [
+        (None, None, None, 3),  # 3 failures
+        (True,),                # older than 30 min → unlocked
+        None,                   # delete from bfa
+    ]
+    result = svc.check_bfa("user@x.com", "1.2.3.4", False)
+    assert result is True

--- a/app/tests/test_csrf_helper.py
+++ b/app/tests/test_csrf_helper.py
@@ -1,0 +1,95 @@
+import pytest
+from flask import Flask, session
+from helpers.csrf_helper import generate_csrf_token, validate_csrf
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({'TESTING': True, 'SECRET_KEY': 'csrf-test-secret'})
+
+    @a.route('/protected', methods=['GET', 'POST'])
+    def protected():
+        validate_csrf()
+        return 'ok', 200
+
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ── generate_csrf_token ──────────────────────────────────────────────────────
+
+def test_generate_csrf_token_creates_token(app):
+    with app.test_request_context('/'):
+        token = generate_csrf_token()
+        assert token is not None
+        assert len(token) == 64  # secrets.token_hex(32) = 64 hex chars
+
+
+def test_generate_csrf_token_reuses_existing(app):
+    with app.test_request_context('/'):
+        session['csrf_token'] = 'existing-token'
+        token = generate_csrf_token()
+        assert token == 'existing-token'
+
+
+def test_generate_csrf_token_unique_per_session(app):
+    with app.test_request_context('/'):
+        t1 = generate_csrf_token()
+    with app.test_request_context('/'):
+        t2 = generate_csrf_token()
+    assert t1 != t2
+
+
+# ── validate_csrf: GET passthrough ───────────────────────────────────────────
+
+def test_get_request_passes_without_token(client):
+    assert client.get('/protected').status_code == 200
+
+
+# ── validate_csrf: POST with form token ─────────────────────────────────────
+
+def test_post_matching_form_token_succeeds(client):
+    with client.session_transaction() as sess:
+        sess['csrf_token'] = 'good-token'
+    resp = client.post('/protected', data={'csrf_token': 'good-token'})
+    assert resp.status_code == 200
+
+
+def test_post_wrong_form_token_fails(client):
+    with client.session_transaction() as sess:
+        sess['csrf_token'] = 'correct'
+    resp = client.post('/protected', data={'csrf_token': 'wrong'})
+    assert resp.status_code == 400
+
+
+def test_post_missing_token_fails(client):
+    with client.session_transaction() as sess:
+        sess['csrf_token'] = 'expected'
+    resp = client.post('/protected', data={})
+    assert resp.status_code == 400
+
+
+def test_post_no_session_token_fails(client):
+    resp = client.post('/protected', data={'csrf_token': 'anything'})
+    assert resp.status_code == 400
+
+
+# ── validate_csrf: POST with header token ────────────────────────────────────
+
+def test_post_matching_header_token_succeeds(client):
+    with client.session_transaction() as sess:
+        sess['csrf_token'] = 'hdr-tok'
+    resp = client.post('/protected', headers={'X-CSRF-Token': 'hdr-tok'})
+    assert resp.status_code == 200
+
+
+def test_post_wrong_header_token_fails(client):
+    with client.session_transaction() as sess:
+        sess['csrf_token'] = 'correct'
+    resp = client.post('/protected', headers={'X-CSRF-Token': 'wrong'})
+    assert resp.status_code == 400

--- a/app/tests/test_decorator_helper.py
+++ b/app/tests/test_decorator_helper.py
@@ -1,0 +1,113 @@
+import pytest
+from flask import Flask, session
+from helpers.decorator_helper import DecoratorHelper
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({'TESTING': True, 'SECRET_KEY': 'dec-test'})
+
+    # Stub redirect targets used by the decorators
+    @a.route('/', endpoint='user.home')
+    def user_home():
+        return 'home', 200
+
+    @a.route('/admin-login', endpoint='admin.admin')
+    def admin_login():
+        return 'admin login', 200
+
+    @a.route('/user-only')
+    @DecoratorHelper.check_login
+    def user_only():
+        return 'user ok', 200
+
+    @a.route('/admin-only')
+    @DecoratorHelper.check_admin_login
+    def admin_only():
+        return 'admin ok', 200
+
+    @a.route('/change_admin_password', endpoint='admin.change_admin_password')
+    @DecoratorHelper.check_admin_login
+    def change_admin_password():
+        return 'change pw ok', 200
+
+    @a.route('/first-login-check')
+    @DecoratorHelper.check_admin_login
+    @DecoratorHelper.check_first_login
+    def first_login_check():
+        return 'past first login', 200
+
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ── check_login ──────────────────────────────────────────────────────────────
+
+def test_check_login_allows_logged_in_user(client):
+    with client.session_transaction() as sess:
+        sess['user_logged_in'] = True
+    assert client.get('/user-only').status_code == 200
+
+
+def test_check_login_redirects_unauthenticated(client):
+    resp = client.get('/user-only')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_check_login_false_flag_redirects(client):
+    with client.session_transaction() as sess:
+        sess['user_logged_in'] = False
+    assert client.get('/user-only').status_code == 302
+
+
+# ── check_admin_login ─────────────────────────────────────────────────────────
+
+def test_check_admin_login_allows_admin(client):
+    with client.session_transaction() as sess:
+        sess['admin_username'] = 'admin'
+    assert client.get('/admin-only').status_code == 200
+
+
+def test_check_admin_login_redirects_unauthenticated(client):
+    resp = client.get('/admin-only')
+    assert resp.status_code == 302
+    assert '/admin-login' in resp.headers['Location']
+
+
+def test_check_admin_login_forgot_token_allows_change_password(client):
+    with client.session_transaction() as sess:
+        sess['forgot_password_token'] = 'reset-token'
+        sess['admin_username'] = 'admin'
+    assert client.get('/change_admin_password').status_code == 200
+
+
+def test_check_admin_login_forgot_token_redirects_other_endpoints(client):
+    with client.session_transaction() as sess:
+        sess['forgot_password_token'] = 'reset-token'
+    resp = client.get('/admin-only')
+    assert resp.status_code == 302
+    assert '/admin-login' in resp.headers['Location']
+
+
+# ── check_first_login ─────────────────────────────────────────────────────────
+
+def test_check_first_login_allows_when_on_login_zero(client):
+    with client.session_transaction() as sess:
+        sess['admin_username'] = 'admin'
+        sess['on_login'] = 0
+    assert client.get('/first-login-check').status_code == 200
+
+
+def test_check_first_login_redirects_when_on_login_one(client):
+    with client.session_transaction() as sess:
+        sess['admin_username'] = 'admin'
+        sess['on_login'] = 1
+    resp = client.get('/first-login-check')
+    assert resp.status_code == 302
+    assert '/admin-login' in resp.headers['Location']

--- a/app/tests/test_rate_limiter.py
+++ b/app/tests/test_rate_limiter.py
@@ -1,0 +1,61 @@
+import time
+import pytest
+from helpers.rate_limiter import RateLimiter
+
+
+@pytest.fixture
+def limiter():
+    return RateLimiter(max_calls=3, period=60)
+
+
+def test_allows_calls_under_limit(limiter):
+    assert limiter.is_allowed("key1") is True
+    assert limiter.is_allowed("key1") is True
+    assert limiter.is_allowed("key1") is True
+
+
+def test_blocks_when_limit_reached(limiter):
+    limiter.is_allowed("key1")
+    limiter.is_allowed("key1")
+    limiter.is_allowed("key1")
+    assert limiter.is_allowed("key1") is False
+
+
+def test_different_keys_tracked_independently(limiter):
+    limiter.is_allowed("a")
+    limiter.is_allowed("a")
+    limiter.is_allowed("a")
+    # 'a' is blocked, 'b' should still be allowed
+    assert limiter.is_allowed("a") is False
+    assert limiter.is_allowed("b") is True
+
+
+def test_calls_expire_after_period():
+    short_limiter = RateLimiter(max_calls=2, period=1)
+    short_limiter.is_allowed("x")
+    short_limiter.is_allowed("x")
+    assert short_limiter.is_allowed("x") is False
+    time.sleep(1.05)
+    assert short_limiter.is_allowed("x") is True
+
+
+def test_window_is_sliding_not_fixed():
+    short_limiter = RateLimiter(max_calls=2, period=1)
+    short_limiter.is_allowed("x")
+    time.sleep(0.6)
+    short_limiter.is_allowed("x")
+    # First call has not expired yet, so third should be blocked
+    assert short_limiter.is_allowed("x") is False
+    time.sleep(0.5)
+    # First call expired, one slot opens up
+    assert short_limiter.is_allowed("x") is True
+
+
+def test_zero_calls_allowed():
+    l = RateLimiter(max_calls=0, period=60)
+    assert l.is_allowed("x") is False
+
+
+def test_new_key_is_always_allowed(limiter):
+    for i in range(10):
+        assert limiter.is_allowed(f"fresh-key-{i}") is True

--- a/app/tests/test_submission_service.py
+++ b/app/tests/test_submission_service.py
@@ -1,0 +1,147 @@
+import pytest
+from unittest.mock import MagicMock
+from flask import Flask, session
+from services.submission_service import SubmissionService
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({'TESTING': True, 'SECRET_KEY': 'sub-svc-test'})
+    return a
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def mail():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(db, mail):
+    return SubmissionService(db=db, mail=mail)
+
+
+def _user_session(sess):
+    sess['First Name'] = 'Alice'
+    sess['Last Name'] = 'Smith'
+    sess['ID Number'] = 'EMP001'
+    sess['Location'] = 'HQ'
+    sess['Email'] = 'alice@example.com'
+
+
+# ── create_submission ─────────────────────────────────────────────────────────
+
+def test_create_submission_success(app, svc, db):
+    db.execute_query.return_value = (99,)
+    with app.test_request_context('/'):
+        _user_session(session)
+        result = svc.create_submission("photo.jpg", "license.jpg")
+    assert result is True
+
+
+def test_create_submission_db_failure(app, svc, db):
+    db.execute_query.return_value = None
+    with app.test_request_context('/'):
+        _user_session(session)
+        result = svc.create_submission("photo.jpg", "license.jpg")
+    assert result is False
+
+
+def test_create_submission_stores_request_id_in_session(app, svc, db):
+    db.execute_query.return_value = (42,)
+    with app.test_request_context('/'):
+        _user_session(session)
+        svc.create_submission("p.jpg", "l.jpg")
+        assert session.get('request_id') == 42
+
+
+# ── approve_request ────────────────────────────────────────────────────────────
+
+def test_approve_request_success(svc, db, mail):
+    db.execute_query.return_value = True
+    result = svc.approve_request("123", actor="admin1")
+    assert result is True
+    mail.send_approved_email.assert_called_once_with("123")
+
+
+def test_approve_request_db_failure(svc, db, mail):
+    db.execute_query.return_value = False
+    result = svc.approve_request("123", actor="admin1")
+    assert result is False
+    mail.send_approved_email.assert_not_called()
+
+
+# ── reject_request ─────────────────────────────────────────────────────────────
+
+def test_reject_request_success(svc, db, mail):
+    db.execute_query.return_value = True
+    result = svc.reject_request("456", "Missing docs", actor="admin1")
+    assert result is True
+    mail.send_rejection_email.assert_called_once_with("456", "Missing docs")
+
+
+def test_reject_request_db_failure(svc, db, mail):
+    db.execute_query.return_value = False
+    result = svc.reject_request("456", "Missing docs", actor="admin1")
+    assert result is False
+    mail.send_rejection_email.assert_not_called()
+
+
+# ── search ─────────────────────────────────────────────────────────────────────
+
+def test_search_returns_results(svc, db):
+    db.execute_query.side_effect = [
+        (3,),                    # count
+        [{'request_id': 1}, {'request_id': 2}, {'request_id': 3}],
+    ]
+    result = svc.search("alice", page=1)
+    assert result is not None
+    assert len(result['search_results']) == 3
+
+
+def test_search_no_results_returns_none(svc, db):
+    db.execute_query.return_value = (0,)
+    result = svc.search("nobody")
+    assert result is None
+
+
+def test_search_pagination_next_page(svc, db):
+    db.execute_query.side_effect = [
+        (30,),  # 2 pages at 15 per page
+        [],
+    ]
+    result = svc.search("term", page=1)
+    assert result['search_pagination']['next_page'] == 2
+    assert result['search_pagination']['prev_page'] is None
+
+
+def test_search_pagination_last_page(svc, db):
+    db.execute_query.side_effect = [
+        (30,),
+        [],
+    ]
+    result = svc.search("term", page=2)
+    assert result['search_pagination']['next_page'] is None
+    assert result['search_pagination']['prev_page'] == 1
+
+
+# ── delete ─────────────────────────────────────────────────────────────────────
+
+def test_delete_success(svc, db):
+    db.execute_query.return_value = True
+    result = svc.delete("789", actor="admin1")
+    assert result is True
+    db.execute_query.assert_called_once_with(
+        "delete from submissions where request_id=%s", ("789",)
+    )
+
+
+def test_delete_db_failure(svc, db):
+    db.execute_query.return_value = False
+    result = svc.delete("789", actor="admin1")
+    assert result is False

--- a/app/tests/test_user_routes.py
+++ b/app/tests/test_user_routes.py
@@ -1,0 +1,186 @@
+import io
+import pytest
+from unittest.mock import patch, MagicMock
+from tests.conftest import make_app
+
+
+JPEG_HEADER = b'\xff\xd8\xff' + b'\x00' * 9
+PNG_HEADER = b'\x89PNG\r\n\x1a\n' + b'\x00' * 4
+
+
+@pytest.fixture
+def app():
+    return make_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user_client(app):
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess['user_logged_in'] = True
+        attrs = {
+            'First Name': 'Alice',
+            'Last Name': 'Smith',
+            'Email': 'alice@example.com',
+            'ID Number': 'EMP001',
+            'Location': 'HQ',
+            'cn': 'alice@example.com',
+        }
+        sess['attrs'] = attrs
+        for k, v in attrs.items():
+            sess[k] = v
+    return c
+
+
+# ── GET / ────────────────────────────────────────────────────────────────────
+
+def test_home_renders_login(client):
+    with patch('routes.user_routes.render_template', return_value='') as mock_rt:
+        resp = client.get('/')
+    assert resp.status_code == 200
+    mock_rt.assert_called_once_with('login.html')
+
+
+# ── POST /login ───────────────────────────────────────────────────────────────
+
+def test_login_blocked_in_entra_mode(app, client):
+    app.config['USER_AUTH_MODE'] = 'entra'
+    resp = client.post('/login', data={'email': 'u@example.com', 'password': 'pass'})
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+    app.config['USER_AUTH_MODE'] = 'ldap'
+
+
+def test_login_success_redirects_to_landing(app, client):
+    app.ldap_service.auth_user.return_value = (
+        None,
+        {'First Name': 'Alice', 'Email': 'alice@example.com', 'cn': 'alice'},
+        True,
+    )
+    app.auth_service.set_session_attrs.return_value = True
+    resp = client.post('/login', data={'email': 'alice@example.com', 'password': 'pass'})
+    assert resp.status_code == 302
+    assert '/landing' in resp.headers['Location']
+
+
+def test_login_failure_redirects_home(app, client):
+    app.ldap_service.auth_user.return_value = (None, {}, False)
+    with patch('routes.user_routes.login_limiter') as mock_lim:
+        mock_lim.is_allowed.return_value = True
+        resp = client.post('/login', data={'email': 'u@example.com', 'password': 'bad'})
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_login_failure_with_message(app, client):
+    app.ldap_service.auth_user.return_value = ("Account locked", {}, False)
+    with patch('routes.user_routes.login_limiter') as mock_lim:
+        mock_lim.is_allowed.return_value = True
+        resp = client.post('/login', data={'email': 'u@example.com', 'password': 'x'})
+    assert resp.status_code == 302
+
+
+def test_login_rate_limited(app, client):
+    with patch('routes.user_routes.login_limiter') as mock_lim:
+        mock_lim.is_allowed.return_value = False
+        resp = client.post('/login', data={'email': 'u@example.com', 'password': 'x'})
+    assert resp.status_code == 302
+    app.ldap_service.auth_user.assert_not_called()
+
+
+# ── GET /landing ──────────────────────────────────────────────────────────────
+
+def test_landing_requires_login(client):
+    resp = client.get('/landing')
+    assert resp.status_code == 302
+    assert '/' in resp.headers['Location']
+
+
+def test_landing_with_session(user_client):
+    with patch('routes.user_routes.render_template', return_value=''):
+        resp = user_client.get('/landing')
+    assert resp.status_code == 200
+
+
+# ── GET /upload_form ──────────────────────────────────────────────────────────
+
+def test_upload_form_requires_login(client):
+    resp = client.get('/upload_form')
+    assert resp.status_code == 302
+
+
+def test_upload_form_with_session(user_client):
+    with patch('routes.user_routes.render_template', return_value=''):
+        resp = user_client.get('/upload_form')
+    assert resp.status_code == 200
+
+
+# ── POST /upload_photo ────────────────────────────────────────────────────────
+
+def _make_upload(filename, content):
+    return (io.BytesIO(content), filename)
+
+
+def test_upload_photo_requires_login(client):
+    resp = client.post('/upload_photo')
+    assert resp.status_code == 302
+
+
+def test_upload_photo_success(app, user_client):
+    app.submission_service.create_submission.return_value = True
+    resp = user_client.post('/upload_photo', content_type='multipart/form-data', data={
+        'photo': _make_upload('photo.jpg', JPEG_HEADER),
+        'drivers_license': _make_upload('license.jpg', JPEG_HEADER),
+    })
+    assert resp.status_code == 302
+    app.submission_service.create_submission.assert_called_once()
+    app.email_service.send_email_alert.assert_called_once()
+
+
+def test_upload_photo_invalid_extension(user_client):
+    resp = user_client.post('/upload_photo', content_type='multipart/form-data', data={
+        'photo': _make_upload('photo.gif', b'GIF89a'),
+        'drivers_license': _make_upload('license.jpg', JPEG_HEADER),
+    })
+    assert resp.status_code == 302
+
+
+def test_upload_photo_bad_magic_bytes(user_client):
+    resp = user_client.post('/upload_photo', content_type='multipart/form-data', data={
+        'photo': _make_upload('photo.jpg', b'\x00' * 12),
+        'drivers_license': _make_upload('license.jpg', JPEG_HEADER),
+    })
+    assert resp.status_code == 302
+
+
+def test_upload_photo_png_accepted(app, user_client):
+    app.submission_service.create_submission.return_value = True
+    resp = user_client.post('/upload_photo', content_type='multipart/form-data', data={
+        'photo': _make_upload('photo.png', PNG_HEADER),
+        'drivers_license': _make_upload('license.png', PNG_HEADER),
+    })
+    assert resp.status_code == 302
+    app.submission_service.create_submission.assert_called_once()
+
+
+def test_upload_photo_submission_failure_cleans_up(app, user_client):
+    app.submission_service.create_submission.return_value = False
+    with patch('routes.user_routes.os.remove') as mock_rm:
+        user_client.post('/upload_photo', content_type='multipart/form-data', data={
+            'photo': _make_upload('photo.jpg', JPEG_HEADER),
+            'drivers_license': _make_upload('license.jpg', JPEG_HEADER),
+        })
+    assert mock_rm.call_count == 2
+
+
+def test_upload_photo_empty_filename_redirects(user_client):
+    resp = user_client.post('/upload_photo', content_type='multipart/form-data', data={
+        'photo': (io.BytesIO(b''), ''),
+        'drivers_license': (io.BytesIO(b''), ''),
+    })
+    assert resp.status_code == 302

--- a/app/tests/test_utility_helper.py
+++ b/app/tests/test_utility_helper.py
@@ -1,0 +1,141 @@
+import io
+import pytest
+from unittest.mock import MagicMock
+from helpers.utility_helper import UtilityHelper
+
+
+# ── generate_unique_filename ─────────────────────────────────────────────────
+
+def test_generate_unique_filename_preserves_extension():
+    name = UtilityHelper.generate_unique_filename("photo.jpg")
+    assert name.endswith(".jpg")
+
+
+def test_generate_unique_filename_is_unique():
+    a = UtilityHelper.generate_unique_filename("photo.png")
+    b = UtilityHelper.generate_unique_filename("photo.png")
+    assert a != b
+
+
+def test_generate_unique_filename_no_original_name_in_output():
+    name = UtilityHelper.generate_unique_filename("original_name.jpg")
+    assert "original_name" not in name
+
+
+def test_generate_unique_filename_handles_unsafe_chars():
+    name = UtilityHelper.generate_unique_filename("bad file name!@#.jpg")
+    assert " " not in name
+    assert "!" not in name
+
+
+# ── is_valid_image ───────────────────────────────────────────────────────────
+
+def _make_file(filename, content):
+    f = MagicMock()
+    f.filename = filename
+    f.stream = io.BytesIO(content)
+    return f
+
+
+JPEG_HEADER = b'\xff\xd8\xff' + b'\x00' * 9
+PNG_HEADER = b'\x89PNG\r\n\x1a\n' + b'\x00' * 4
+WEBP_HEADER = b'RIFF' + b'\x00' * 4 + b'WEBP'
+
+
+def test_is_valid_image_jpeg():
+    assert UtilityHelper.is_valid_image(_make_file("photo.jpg", JPEG_HEADER))
+
+
+def test_is_valid_image_jpeg_uppercase_extension():
+    assert UtilityHelper.is_valid_image(_make_file("photo.JPG", JPEG_HEADER))
+
+
+def test_is_valid_image_png():
+    assert UtilityHelper.is_valid_image(_make_file("photo.png", PNG_HEADER))
+
+
+def test_is_valid_image_webp():
+    assert UtilityHelper.is_valid_image(_make_file("photo.webp", WEBP_HEADER))
+
+
+def test_is_valid_image_wrong_extension():
+    assert not UtilityHelper.is_valid_image(_make_file("photo.gif", JPEG_HEADER))
+
+
+def test_is_valid_image_txt_extension():
+    assert not UtilityHelper.is_valid_image(_make_file("file.txt", JPEG_HEADER))
+
+
+def test_is_valid_image_valid_extension_wrong_magic():
+    garbage = b'\x00' * 12
+    assert not UtilityHelper.is_valid_image(_make_file("photo.jpg", garbage))
+
+
+def test_is_valid_image_cross_format_magic_accepted():
+    # is_valid_image checks magic bytes against any supported format, not against the extension.
+    # A .png file with JPEG magic bytes is accepted — content wins over extension name.
+    assert UtilityHelper.is_valid_image(_make_file("photo.png", JPEG_HEADER)) is True
+
+
+def test_is_valid_image_resets_stream():
+    f = _make_file("photo.jpg", JPEG_HEADER)
+    UtilityHelper.is_valid_image(f)
+    assert f.stream.tell() == 0
+
+
+# ── check_password_complexity ────────────────────────────────────────────────
+
+@pytest.fixture
+def app_ctx():
+    """Minimal Flask context so flash() can run."""
+    from flask import Flask
+    a = Flask(__name__)
+    a.config['TESTING'] = True
+    a.config['SECRET_KEY'] = 'test'
+    with a.test_request_context('/'):
+        with a.test_client() as c:
+            with c.session_transaction():
+                pass
+        yield
+
+
+def test_check_password_complexity_valid(app_ctx):
+    assert UtilityHelper.check_password_complexity("Abcdef1!") is True
+
+
+def test_check_password_complexity_strong(app_ctx):
+    assert UtilityHelper.check_password_complexity("$ecureP4ssw0rd!") is True
+
+
+def test_check_password_complexity_too_short(app_ctx):
+    assert UtilityHelper.check_password_complexity("Ab1!") is False
+
+
+def test_check_password_complexity_no_uppercase(app_ctx):
+    assert UtilityHelper.check_password_complexity("abcdef1!") is False
+
+
+def test_check_password_complexity_no_lowercase(app_ctx):
+    assert UtilityHelper.check_password_complexity("ABCDEF1!") is False
+
+
+def test_check_password_complexity_no_digit(app_ctx):
+    assert UtilityHelper.check_password_complexity("Abcdefg!") is False
+
+
+def test_check_password_complexity_no_special(app_ctx):
+    assert UtilityHelper.check_password_complexity("Abcdef12") is False
+
+
+def test_check_password_complexity_too_long(app_ctx):
+    long_pass = "Aa1!" + "x" * 125
+    assert len(long_pass) > 128
+    assert UtilityHelper.check_password_complexity(long_pass) is False
+
+
+def test_check_password_complexity_exactly_8_chars(app_ctx):
+    assert UtilityHelper.check_password_complexity("Abcde1!x") is True
+
+
+def test_check_password_complexity_underscore_as_special(app_ctx):
+    assert UtilityHelper.check_password_complexity("Abcdef1_") is True


### PR DESCRIPTION
## Summary

- Adds 181 unit tests covering every significant component in the app
- Tests run entirely with mocked services — no database, LDAP, or SMTP connection required
- Adds `pytest==8.3.5` to `requirements.txt` so it is available after image rebuilds
- Adds `app/pytest.ini` configuring `testpaths = tests` and `pythonpath = .`

## Test coverage

| Module | Tests |
|---|---|
| `helpers/utility_helper.py` | 19 — filename generation, JPEG/PNG/WebP magic bytes, password complexity |
| `helpers/rate_limiter.py` | 7 — sliding window, multi-key isolation, period expiry |
| `helpers/csrf_helper.py` | 10 — token generation/reuse, GET passthrough, form & header token validation |
| `helpers/decorator_helper.py` | 9 — `check_login`, `check_admin_login` (incl. forgot-password-token bypass), `check_first_login` |
| `services/auth_service.py` | 28 — local login, BFA lockout/reset, password change, forgot-password tokens, Entra flows |
| `services/admin_service.py` | 14 — create/edit/delete, all panel tabs with pagination |
| `services/submission_service.py` | 13 — create, approve, reject, search (pagination, no results), delete |
| `routes/admin_routes.py` | 47 — all admin routes, auth mode enforcement, RBAC, batch ops |
| `routes/user_routes.py` | 16 — home, LDAP login, rate limiting, entra block, file upload validation |
| `routes/auth_routes.py` | 13 — OAuth login mode guards, callback success/fail for admin and user flows |

## How to run

```bash
# After rebuilding the image:
docker compose exec flask python -m pytest tests/ -v

# Or without rebuilding (install pytest in running container):
docker exec flask_test pip install pytest
docker exec flask_test python -m pytest tests/ -v
```

## Test plan

- [x] All 181 tests pass in the running test container
- [x] No real DB, LDAP, or SMTP connections required — all services are mocked
- [x] Auth mode enforcement tested for `local`, `entra`, and `both` modes
- [x] RBAC tested — super vs manager role restrictions verified
- [x] BFA lockout logic tested including the 30-minute reset window

🤖 Generated with [Claude Code](https://claude.com/claude-code)