### PR TITLE
docs: add technical documentation in doc/

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -1,0 +1,238 @@
+# Algorithms and Security Mechanisms
+
+---
+
+## Brute-force lockout (BFA)
+
+**Location:** `services/auth_service.py` — `AuthService.check_bfa`  
+**Triggers on:** Admin local login (`POST /admin`) and LDAP user login (`POST /login`)
+
+### How it works
+
+The `bfa` table holds one row per targeted account identifier (username or email). The algorithm runs as a guard both *before* and *after* a credential check.
+
+**Before the credential check** (`failed=False`):
+
+```
+SELECT * FROM bfa WHERE email = ?
+├── No row found
+│     └── allow login attempt (return True)
+└── Row found
+      ├── failed_attempts < 3
+      │     └── allow login attempt (return True)
+      └── failed_attempts >= 3
+            ├── (now - timestamp_inserted) > 30 min  → delete row, return True
+            └── (now - timestamp_inserted) <= 30 min → log lockout time, return False
+```
+
+**After a failed credential check** (`failed=True`):
+
+```
+SELECT * FROM bfa WHERE email = ?
+├── No row found
+│     └── INSERT bfa (email, ip_address)  [failed_attempts defaults to 1]
+└── Row found, failed_attempts < 3
+      └── UPDATE bfa SET failed_attempts = failed_attempts + 1,
+                         timestamp_inserted = now()
+```
+
+Note: when `failed_attempts >= 3` and `failed=True` (i.e. repeated attempts while locked), the update branch is not reached because `check_bfa` returns `False` before the credential check even runs, so the second `check_bfa(failed=True)` call never happens.
+
+### Key design decisions
+
+- **Sliding window from last failure:** `timestamp_inserted` is updated to `now()` on every failed-attempt increment. The 30-minute window restarts from the most recent failure, not the first. This prevents a slow drip attack (one attempt every 29 minutes) from evading the lockout.
+- **Account-level, not IP-level:** The lockout key is the targeted username/email, not the source IP. Multiple IPs attacking the same account cooperatively consume the failure budget. A single IP attacking multiple accounts is not blocked by this mechanism — rate limiting handles that (see below).
+- **No automatic reset on successful login:** Rows are only deleted when the 30-minute window expires. A successful login after the window expires will find no row and proceed normally.
+
+---
+
+## Rate limiting
+
+**Location:** `helpers/rate_limiter.py` — `RateLimiter`  
+**Instances:** `forgot_password_limiter` (5 req / 5 min), `login_limiter` (10 req / 5 min)
+
+### Algorithm: sliding window counter
+
+```python
+def is_allowed(self, key: str) -> bool:
+    now = time.time()
+    with self._lock:
+        calls = self._calls[key]
+        calls[:] = [t for t in calls if now - t < self.period]  # evict expired timestamps
+        if len(calls) >= self.max_calls:
+            return False
+        calls.append(now)
+        return True
+```
+
+Each `key` (typically a remote IP) maps to a list of timestamps. On every call:
+1. Timestamps older than `period` seconds are removed in place.
+2. If the remaining count meets or exceeds `max_calls`, the request is denied.
+3. Otherwise the current timestamp is appended and the request is allowed.
+
+This is a true sliding window (not a fixed bucket). A client that makes 5 requests in the last second of a window cannot "reload" on the first second of the next window.
+
+### Trade-offs
+
+- **In-memory only:** The store is a `defaultdict(list)` on the process. In a multi-worker Gunicorn setup, each worker has an independent counter. A client can make `max_calls × worker_count` requests before any single worker rejects them. With 4 workers and `login_limiter(10, 300)`, that is effectively 40 attempts per 5 minutes per IP per deployment. This is acceptable given BFA and bcrypt cost also slow attacks.
+- **No persistence:** Counters reset on container restart.
+- **Thread safety:** A `threading.Lock` protects the shared dict. This is correct for Gunicorn's sync (pre-fork, threaded) workers.
+
+---
+
+## CSRF protection
+
+**Location:** `helpers/csrf_helper.py`  
+**Applied:** `app.before_request(validate_csrf)` — runs on every request before any route handler.
+
+### Double-submit cookie pattern
+
+```python
+def generate_csrf_token() -> str:
+    if 'csrf_token' not in session:
+        session['csrf_token'] = secrets.token_hex(32)
+    return session['csrf_token']
+
+def validate_csrf() -> None:
+    if request.method != 'POST':
+        return
+    token = session.get('csrf_token')
+    form_token = request.form.get('csrf_token') or request.headers.get('X-CSRF-Token')
+    if not token or not form_token or not hmac.compare_digest(token, form_token):
+        abort(400)
+```
+
+On the first GET to any page, `generate_csrf_token()` (called from the context processor) stores a 64-character hex token in the session cookie. Every HTML form includes a hidden `<input name="csrf_token">` with this value. On POST, `validate_csrf` compares the session token against the submitted value using `hmac.compare_digest` (constant-time comparison, preventing timing attacks).
+
+AJAX endpoints can also pass the token in the `X-CSRF-Token` header — the check accepts either.
+
+GET, HEAD, and other safe methods are exempt.
+
+---
+
+## Password hashing
+
+**Location:** `services/auth_service.py`
+
+bcrypt with an auto-generated salt (cost factor determined by `bcrypt.gensalt()`, currently 12 rounds).
+
+```python
+salt = bcrypt.gensalt()
+hashed = bcrypt.hashpw(password.encode('utf-8'), salt).decode('utf-8')
+```
+
+The stored string is the full bcrypt output: `$2b$12$<22-char salt><31-char hash>` (60 chars). Verification uses `bcrypt.checkpw` which re-derives the hash using the embedded salt and compares in constant time.
+
+**Password complexity rules** (`helpers/utility_helper.py`):
+- Minimum 8 characters, maximum 128 characters
+- Must contain: at least one lowercase letter, one uppercase letter, one digit, one non-alphanumeric character (`[\W_]` — underscore counts)
+- Enforced by regex: `^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$`
+- The maximum of 128 is a DoS guard: bcrypt has O(n) cost per character; extremely long passwords can be used to exhaust CPU.
+
+---
+
+## Password reset token
+
+**Location:** `services/auth_service.py` — `gen_random_forgot_password_link`, `_hash_token`
+
+```python
+token = uuid4().hex          # 32-char random hex string
+url   = f"{FORGOT_PASSWORD_URL}?token={token}"
+stored = sha256(token.encode()).hexdigest()   # 64-char hex
+```
+
+The raw token is embedded in the URL sent to the user. Only the SHA-256 hash is stored in the database. If the `admin_forgot_password` table is dumped, the hashes cannot be used directly — an attacker would need to find a UUID4 that hashes to a known value, which is computationally infeasible.
+
+UUID4 provides 122 bits of entropy (4 bits are version/variant markers). Token expiry is enforced at the database level via `expire_after`.
+
+---
+
+## Image validation
+
+**Location:** `helpers/utility_helper.py` — `is_valid_image`
+
+Two-stage validation:
+
+1. **Extension check:** The filename (after `werkzeug.utils.secure_filename` normalisation) must have an extension in `{.jpg, .jpeg, .png, .webp}`.
+2. **Magic bytes check:** The first 12 bytes of the file stream are read and compared against known signatures:
+   - JPEG: `\xff\xd8\xff`
+   - PNG: `\x89PNG\r\n\x1a\n`
+   - WebP: `RIFF....WEBP` (bytes 0–3 are `RIFF`, bytes 8–11 are `WEBP`)
+
+The stream seek position is reset to 0 after reading. The extension and magic bytes are checked independently — a valid magic signature in any accepted format is sufficient regardless of whether it matches the file extension. This intentionally accepts, for example, a JPEG renamed to `.png`.
+
+The combination of extension + magic byte checks blocks common attack vectors: an attacker cannot upload a PHP/shell script by renaming it `.jpg` (the magic bytes won't match), and cannot bypass the extension check by using a valid JPEG header inside a `.php` file (the extension check fails first).
+
+---
+
+## File storage
+
+**Location:** `helpers/utility_helper.py` — `generate_unique_filename`
+
+```python
+def generate_unique_filename(filename: str) -> str:
+    filename = secure_filename(filename)          # strip path traversal, sanitise
+    _, extension = os.path.splitext(filename)
+    return f"{uuid4()}{extension}"               # e.g. "3f2a...c1.jpg"
+```
+
+Original filenames are discarded. The stored name is `UUID4 + original extension`. UUID4 provides a namespace large enough that collisions are negligible (2^122 values). The extension is kept only for MIME type hints in the future — the actual content type is validated by magic bytes before this function is called.
+
+Files are stored in the `uploads` Docker named volume at `/app/uploads/` inside the container. They are served via the authenticated route `GET /uploads/<path:filename>` which is guarded by `@DecoratorHelper.check_admin_login`.
+
+---
+
+## Full-text search
+
+**Location:** `services/submission_service.py` — `search`  
+**Database:** `search_vector` generated column on `submissions`
+
+PostgreSQL's built-in `tsvector`/`tsquery` engine is used.
+
+The `search_vector` column is defined as:
+
+```sql
+GENERATED ALWAYS AS (
+    to_tsvector('english',
+        COALESCE(first_name,'') || ' ' || COALESCE(last_name,'') || ' ' ||
+        COALESCE(id_number,'') || ' ' || COALESCE(email,'') || ' ' ||
+        COALESCE(location::text,'') || ' ' || COALESCE(comments::text,'')
+    )
+) STORED
+```
+
+Search query:
+
+```sql
+SELECT * FROM submissions
+WHERE search_vector @@ plainto_tsquery('english', ?)
+ORDER BY request_id
+LIMIT ? OFFSET ?
+```
+
+`plainto_tsquery` converts a free-text search string into a `tsquery` with implicit `AND` between all non-stop words. The `@@` operator checks whether the `tsvector` matches. The GIN index on `search_vector` enables this without a sequential scan.
+
+The `english` text search configuration applies the Snowball stemming algorithm (e.g. "approved" and "approve" both match) and strips common English stop words.
+
+---
+
+## LDAP authentication flow
+
+**Location:** `services/ldap_service.py`
+
+Two-step bind pattern:
+
+1. **Service account bind:** Connect to the LDAP server using the configured service account (`LDAP_BIND_DN` / `LDAP_BIND_PWD`) and search for the user entry matching the submitted email via `LDAP_SEARCH_FILTER`.
+2. **User bind:** Disconnect the service connection, re-connect, and bind using the user's distinguished name (DN) returned from the search and the password the user submitted. If this bind succeeds, the credentials are valid.
+
+This pattern is necessary because LDAP does not have a "verify password" primitive — the only way to check a password is to attempt a bind as that user.
+
+TLS is applied via `StartTLS` (LDAP over port 389 upgraded to TLS) when `LDAP_USE_TLS=true`. The `LDAP_TLS_CACERTFILE` path is set as the CA trust store for certificate validation.
+
+`LDAP_ATTRIBUTES` is a JSON mapping of display name → LDAP attribute name, e.g.:
+```json
+{"First Name": "givenName", "Last Name": "sn", "ID Number": "employeeID"}
+```
+This makes the attribute mapping configurable without code changes for different directory schemas.
+
+**Duplicate-submission guard:** Before attempting authentication, `check_user_submissions` queries whether the submitting email already has a pending (`N`) or approved (`A`) submission. If so, the login is blocked with a message directing the user to contact their administrator. This prevents double-submissions without requiring the user to have a separate account state.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,174 @@
+# Architecture
+
+## Overview
+
+IDPortal is a multi-container Flask application. All containers are defined in `docker-compose.yml` (production) and `docker-compose.test.yml` (test stack). The application source is baked into the Flask image at build time — there is no volume mount for code.
+
+## Container layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Host                                                           │
+│                                                                 │
+│  :8080 (HTTP)  :8443 (HTTPS)  :8025 (MailHog, test only)       │
+└────────┬──────────────┬──────────────────────────────────────────┘
+         │              │
+┌────────▼──────────────▼──────────┐
+│  nginx                           │  SSL termination, HTTP→HTTPS
+│  nginx:1.27-alpine               │  redirect, static file serving
+└────────────────┬─────────────────┘
+                 │  proxy_pass http://flask:5000
+┌────────────────▼─────────────────┐
+│  flask (Gunicorn + Flask 3.1)    │  Application logic
+│  4 sync workers                  │
+└──────┬──────────────┬────────────┘
+       │              │
+┌──────▼──────┐  ┌────▼───────────────────────────────────────┐
+│  db          │  │  ldap (test stack only)                    │
+│  PostgreSQL  │  │  osixia/openldap — stands in for AD in dev │
+│  16          │  └────────────────────────────────────────────┘
+└─────────────┘
+```
+
+**Production** uses an external LDAP/Active Directory server. The `ldap` container only exists in the test stack.
+
+## Python application structure
+
+```
+app/
+├── app.py                  Application factory (create_app)
+├── factories/
+│   └── log_factory.py      Shared RotatingFileHandler logger factory
+├── helpers/
+│   ├── csrf_helper.py      CSRF token generation and validation
+│   ├── decorator_helper.py Route guard decorators
+│   ├── rate_limiter.py     In-memory sliding-window rate limiter
+│   └── utility_helper.py  Filename generation, image validation, password rules
+├── routes/
+│   ├── admin_routes.py     Admin portal routes (/admin, /admin_panel, …)
+│   ├── user_routes.py      End-user routes (/, /login, /upload_photo, …)
+│   └── auth_routes.py      OAuth 2.0 / Entra ID callback routes
+├── services/
+│   ├── auth_service.py     Authentication logic (local + Entra), session management, BFA
+│   ├── admin_service.py    Admin CRUD and panel data population
+│   ├── db_utils.py         psycopg2 connection pool wrapper
+│   ├── email_service.py    All outbound email via Flask-Mail
+│   ├── ldap_service.py     LDAP bind, user search, credential verification
+│   └── submission_service.py  ID request lifecycle (create, approve, reject, delete, search)
+├── templates/              Jinja2 HTML and email templates
+├── static/                 CSS, JS, images
+├── tests/                  pytest unit tests (see testing.md)
+└── pytest.ini
+```
+
+## Request lifecycle
+
+### End-user login (LDAP path)
+
+```
+POST /login
+  → rate_limiter.is_allowed(remote_addr)     [blocks after 10 req / 5 min]
+  → LDAPService.auth_user(email, password)
+      → AuthService.check_bfa(email, ip, failed=False)   [blocks if locked]
+      → LDAPService.check_user_submissions(email)         [blocks if pending/approved]
+      → LDAPService.search_user(email)                    [service-account bind + search]
+      → ldap.simple_bind_s(user_dn, password)             [credential verify]
+  → AuthService.set_session_attrs(attrs)
+  → redirect /landing
+```
+
+### Admin login (local path)
+
+```
+POST /admin
+  → AuthService.admin_login(username, password)
+      → AuthService.check_bfa(username, ip, failed=False)
+      → SELECT admins WHERE username = %s
+      → bcrypt.checkpw(password, stored_hash)
+      → on failure: check_bfa(username, ip, failed=True)  [increment / insert BFA record]
+      → on success: populate session
+  → redirect /admin_panel  (or /change_admin_password if on_login=1)
+```
+
+### OAuth (Entra ID) path
+
+```
+GET /oauth/login?flow=admin|user
+  → validate ENTRA_CLIENT_ID configured + auth mode allows it
+  → store flow in session['oauth_flow']
+  → authlib: redirect to Microsoft authorize endpoint
+
+GET /oauth/callback
+  → authlib: exchange code for token, fetch userinfo from id_token
+  → flow == 'admin': AuthService.entra_admin_login(userinfo)
+  → flow == 'user':  AuthService.entra_user_login(userinfo)
+  → redirect to appropriate destination
+```
+
+## Service dependencies
+
+Services are instantiated once in `create_app()` and attached to the `app` object. Routes access them via `current_app.<service>`.
+
+```
+Database
+  └── used by: AuthService, AdminService, SubmissionService,
+               EmailService, LDAPService
+
+AuthService(db)
+  └── used by: LDAPService, admin_routes, auth_routes
+
+LDAPService(auth_service, app, db)
+  └── used by: user_routes
+
+EmailService(db, app)
+  └── used by: admin_routes, user_routes
+
+AdminService(db)
+  └── used by: admin_routes
+
+SubmissionService(db, email_service)
+  └── used by: admin_routes, user_routes
+```
+
+## Session design
+
+Flask's signed cookie session (`itsdangerous`) is used. No server-side session store.
+
+**Admin session keys:**
+
+| Key | Type | Description |
+|---|---|---|
+| `admin_username` | str | Username — presence signals admin is logged in |
+| `first_name` | str | Display name |
+| `last_name` | str | Display name |
+| `email` | str | Admin email |
+| `role` | str | `super` or `manager` |
+| `on_login` | int | `1` = must change password before proceeding |
+| `user_id` | int | `admins.id` |
+| `forgot_password_token` | str | Set during password-reset flow; unlocks `/change_admin_password` |
+
+**User session keys:**
+
+| Key | Type | Description |
+|---|---|---|
+| `user_logged_in` | bool | True when authenticated |
+| `attrs` | dict | Raw LDAP/Entra attributes dict |
+| `First Name` | str | Pulled from attrs for template use |
+| `Last Name` | str | |
+| `Email` | str | |
+| `ID Number` | str | employeeID from LDAP |
+| `Location` | str | physicalDeliveryOfficeName from LDAP |
+| `cn` | str | sAMAccountName / preferred_username |
+| `request_id` | int | Set after successful submission insert |
+
+Sessions are permanent with an 8-hour lifetime (`PERMANENT_SESSION_LIFETIME`). The cookie is `HttpOnly`, `SameSite=Lax`, and `Secure=True` (the last two enforced by nginx in production).
+
+## Logging
+
+Each service creates its own named logger via `factories.get_logger(name)`. All loggers write to `logs/<name>.log` using a `RotatingFileHandler` (1 MB max, 5 backups). The `logs/` directory is a Docker named volume so logs persist across container restarts. Log format:
+
+```
+[YYYY-MM-DD HH:MM:SS] {service_name}: LEVEL - message
+```
+
+Audit-relevant events (submission approve / reject / delete) are written with the prefix `[AUDIT]` to make them grep-able.

--- a/doc/database.md
+++ b/doc/database.md
@@ -1,0 +1,144 @@
+# Database
+
+PostgreSQL 16. Schema defined in `docker/db/init.sql`. The database user is `idportal` and has `SELECT`, `INSERT`, `UPDATE`, `DELETE` on all tables, plus `USAGE` on all sequences. It does not have DDL privileges — schema changes require a superuser connection.
+
+---
+
+## Tables
+
+### `admins`
+
+Stores admin portal accounts.
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | `integer` | auto (sequence) | Primary key |
+| `first_name` | `text` | — | Display name |
+| `last_name` | `text` | — | Display name |
+| `username` | `varchar(20)` | — | Login identifier; unique |
+| `password` | `text` | — | bcrypt hash (cost 12) |
+| `email` | `text` | — | Used for Entra login matching and password reset; unique |
+| `status` | `integer` | `1` | `1` = active, `0` = disabled |
+| `on_login` | `integer` | `1` | `1` = must change password on next login; reset to `0` after change |
+| `role` | `varchar(8)` | — | `super` or `manager` |
+
+**Constraints:** `admins_pkey` (PK on `id`), `admins_email_key` (UNIQUE on `email`), `admins_username_key` (UNIQUE on `username`).
+
+**Indexes:** B-tree on `id`, `username`, `email` — all three are frequent lookup keys.
+
+**Notes:**
+- `on_login = 1` is set on every newly created account. The deploy script also sets it on the bootstrap super admin. This forces a password change via the `/change_admin_password` route before the admin can access anything else.
+- `password` stores the full bcrypt output string (60 chars), which embeds the algorithm version, cost factor, and salt. The plain-text password is never stored or logged.
+- In Entra-only mode (`ADMIN_AUTH_MODE=entra`) the `password` column contains a randomly generated bcrypt hash that is never used; `username` is auto-derived from the email prefix.
+
+---
+
+### `admin_forgot_password`
+
+Holds single-use password-reset tokens.
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | `integer` | auto | Primary key |
+| `user_id` | `integer` | — | FK → `admins.id` |
+| `token` | `varchar(64)` | — | SHA-256 hex digest of the raw token |
+| `expire_after` | `timestamptz` | `now() + 30 min` | Token expiry; overridden to `+24 hours` on account creation emails |
+
+**Constraints:** `admin_forgot_password_pkey` (PK on `id`), FK on `user_id` referencing `admins(id)`.
+
+**Notes:**
+- The raw token (UUID4 hex, 32 chars) is sent in the reset URL. Only the SHA-256 hash of that token is stored. This means a database breach does not expose usable reset links.
+- On forgot-password form submit, a dummy `gen_random_forgot_password_link()` call is made even when the account does not exist. This normalises response time and prevents username/email enumeration.
+- Tokens are deleted from this table immediately after a successful password reset (`del_forgot_password_token`).
+- Multiple tokens can exist for the same `user_id`. The query validates by token hash only; if a user requests multiple resets, all are usable until expiry. Tokens are short-lived (30 min for forgot-password flow, 24 hours for welcome emails), so this is acceptable.
+
+---
+
+### `submissions`
+
+One row per ID request submitted by an end user.
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `request_id` | `integer` | auto | Primary key |
+| `first_name` | `text` | — | From LDAP/Entra at time of submission |
+| `last_name` | `text` | — | |
+| `email` | `text` | — | |
+| `id_number` | `text` | — | Employee/student ID (employeeID from LDAP) |
+| `location` | `varchar(15)` | — | Campus/office (physicalDeliveryOfficeName from LDAP) |
+| `timestamp_inserted` | `timestamptz` | `now()` | Submission time |
+| `status` | `varchar(1)` | `'N'` | `N` = pending, `A` = approved, `R` = rejected |
+| `ip_address` | `inet` | — | Populated by DB default (currently unused at app level — see note) |
+| `photo_filepath` | `text` | — | UUID-based filename in the `uploads` volume |
+| `license_filepath` | `text` | — | UUID-based filename in the `uploads` volume |
+| `comments` | `varchar(250)` | — | Rejection reason; null for pending/approved |
+| `search_vector` | `tsvector` | generated | Full-text search index (see below) |
+
+**Constraints:** `submissions_pkey` (PK on `request_id`).
+
+**Indexes:**
+- B-tree on `status` — all panel queries filter by status.
+- B-tree on `email` — duplicate-submission check.
+- B-tree on `id_number` — search support.
+- GIN on `search_vector` — full-text search.
+
+**`search_vector` generated column:**
+
+```sql
+to_tsvector('english',
+    COALESCE(first_name,'') || ' ' ||
+    COALESCE(last_name,'') || ' ' ||
+    COALESCE(id_number,'') || ' ' ||
+    COALESCE(email,'') || ' ' ||
+    COALESCE(location::text,'') || ' ' ||
+    COALESCE(comments::text,'')
+)
+```
+
+This is a `GENERATED ALWAYS AS ... STORED` column. PostgreSQL recomputes and stores it automatically on every insert/update. The `english` dictionary applies stemming and stop-word removal. Searches use `plainto_tsquery('english', ?)` which tokenises the search term the same way. GIN indexing on `tsvector` gives O(log n) lookup rather than a sequential scan.
+
+**Note on `ip_address`:** The column exists in the schema but the application layer does not pass a value on insert (the `INSERT` statement in `submission_service.py` does not include it). PostgreSQL accepts the omission and stores `NULL`.
+
+---
+
+### `bfa`
+
+Brute-force protection tracking table for admin login attempts. See also [algorithms.md — Brute-force lockout](algorithms.md#brute-force-lockout-bfa).
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | `integer` | auto | Primary key |
+| `email` | `text` | — | The username/email that was targeted |
+| `ip_address` | `inet` | — | Source IP of the first failed attempt |
+| `failed_attempts` | `integer` | `1` | Incremented on each subsequent failure |
+| `timestamp_inserted` | `timestamp` (no tz) | `now()` | Reset to `now()` on each increment |
+
+**Constraints:** `bfa_pkey` (PK on `id`), `bfa_email_key` (UNIQUE on `email`).
+
+**Indexes:** B-tree on `email` — every auth attempt does a lookup by email.
+
+**Notes:**
+- One row per targeted username. Multiple IPs attacking the same account will still lock it out after 3 total failures.
+- `timestamp_inserted` is refreshed (`= now()`) on every failed-attempt increment, meaning the 30-minute window is a sliding window from the *last* failure, not the first.
+- Rows are deleted when the lockout window expires (not on successful login). A successful login after the window naturally re-creates a clean row if needed.
+
+---
+
+## Entity relationship
+
+```
+admins (1) ──────────────── (0..*) admin_forgot_password
+       id                          user_id (FK)
+
+submissions — no FK relationships; email is the only join key
+              (intentional: submissions must survive admin account deletion)
+
+bfa — no FK relationships; email is a free-text key matching the login
+      identifier, which may be a username rather than a real email
+```
+
+---
+
+## Connection pooling
+
+`db_utils.py` wraps a `psycopg2.pool.ThreadedConnectionPool` with `minconn=2`, `maxconn=10`. Connections are checked out for the duration of a single query and immediately returned to the pool. All writes commit on success and roll back on exception. The pool is shared across Gunicorn's sync workers via the Flask `app` object — because Gunicorn prefork workers do not share memory, each worker has its own pool instance.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,19 @@
+# IDPortal — Technical Documentation
+
+## Contents
+
+| Document | What it covers |
+|---|---|
+| [architecture.md](architecture.md) | Container layout, Python module structure, request lifecycles, session design, logging |
+| [database.md](database.md) | Full schema: all tables, columns, types, constraints, indexes, foreign keys, design notes |
+| [algorithms.md](algorithms.md) | BFA lockout, sliding-window rate limiter, CSRF, bcrypt password hashing, reset tokens, image magic-byte validation, full-text search, LDAP two-step bind |
+| [services.md](services.md) | Every service class and method — signatures, behaviour, dependencies |
+| [routes.md](routes.md) | Every HTTP route — method, path, auth guards, request parameters, response format |
+| [testing.md](testing.md) | How to run tests, test architecture, mocking patterns, adding new tests |
+
+## Quick orientation
+
+- Entry point: `app/app.py` — `create_app()` wires everything together.
+- All services are on `current_app.<name>`; routes never instantiate services themselves.
+- Schema migrations are manual — edit `docker/db/init.sql` and rebuild the `db` image.
+- Auth mode (local vs Entra vs both) is controlled entirely by `ADMIN_AUTH_MODE` and `USER_AUTH_MODE` env vars; no code changes needed to switch modes.

--- a/doc/routes.md
+++ b/doc/routes.md
@@ -1,0 +1,220 @@
+# Routes
+
+All routes are registered on the Flask `app` via blueprints in `create_app()`. CSRF validation runs as a `before_request` hook on every POST. The `ProxyFix` middleware is applied so `request.remote_addr` reflects the real client IP from the `X-Forwarded-For` header set by nginx.
+
+---
+
+## Auth modes
+
+Two environment variables control which login paths are active:
+
+| Variable | Values | Effect |
+|---|---|---|
+| `ADMIN_AUTH_MODE` | `local` (default) | Password form only; Microsoft button hidden; OAuth and password-reset routes blocked in Entra-only mode |
+| | `entra` | Microsoft sign-in only; password form hidden; `POST /admin` and `/forgot_password` routes reject with flash |
+| | `both` | Both methods shown |
+| `USER_AUTH_MODE` | `ldap` (default) | LDAP form only |
+| | `entra` | Microsoft sign-in only; `POST /login` rejects with flash |
+| | `both` | Both methods shown |
+
+These values are injected into every template via the `inject_globals` context processor as `admin_auth_mode` and `user_auth_mode`.
+
+---
+
+## Route guards (decorators)
+
+Defined in `helpers/decorator_helper.py`. Applied as stacked decorators — Flask calls them outer-first, so `check_admin_login` runs before `check_first_login`.
+
+### `@DecoratorHelper.check_login`
+Checks `session['user_logged_in']` is truthy. Redirects to `/` on failure.
+
+### `@DecoratorHelper.check_admin_login`
+Special case: if `forgot_password_token` is in session, only the `admin.change_admin_password` endpoint is allowed through; any other endpoint redirects to `/admin`.
+
+Otherwise: checks `session['admin_username']` is present. Redirects to `/admin` on failure.
+
+### `@DecoratorHelper.check_first_login`
+Checks `session['on_login'] != 1`. Redirects to `/admin` if the admin has not yet changed their initial password.
+
+---
+
+## User routes (`routes/user_routes.py`)
+
+Blueprint: `user`, prefix: `/`
+
+### `GET /`
+Renders `login.html`. No auth required. The template conditionally shows the LDAP form and/or the Microsoft button based on `user_auth_mode` and `entra_enabled`.
+
+### `POST /login`
+LDAP authentication endpoint.
+
+- Blocked (redirect `/`) if `USER_AUTH_MODE == "entra"`.
+- Rate-limited by `login_limiter` (10 req / 5 min per IP).
+- Delegates to `LDAPService.auth_user(email, password)`.
+- On success: `AuthService.set_session_attrs(attrs)` → redirect `/landing`.
+- On failure: flash error → redirect `/`.
+
+### `GET /landing`
+**Guard:** `check_login`  
+Renders `landing.html` with `attrs=session['attrs']`. Shows the user their LDAP/Entra profile data and the link to the upload form.
+
+### `GET /upload_form`
+**Guard:** `check_login`  
+Renders `upload_photo.html` — the photo and licence upload form.
+
+### `POST /upload_photo`
+**Guard:** `check_login`  
+Handles file submission.
+
+1. Validates both `photo` and `drivers_license` fields are present and non-empty.
+2. Calls `UtilityHelper.is_valid_image()` on each file — rejects with flash if invalid.
+3. Generates UUID filenames and saves to `UPLOAD_FOLDER`.
+4. Calls `SubmissionService.create_submission(photo_fn, license_fn)`.
+5. On success: sends admin email alert → redirect `/logout` (clears user session).
+6. On DB failure: deletes the saved files, flashes error, redirect `/logout`.
+
+Saving files before the DB insert means a DB failure requires cleanup (the `os.remove` calls in the failure branch). The reverse order (insert first, then save) would be cleaner but the current code handles it correctly.
+
+---
+
+## Admin routes (`routes/admin_routes.py`)
+
+Blueprint: `admin`, prefix: `/`
+
+Input validation constants at module level:
+- `_VALID_ROLES = {'manager', 'super'}`
+- `_MAX_COMMENT_LEN = 250`
+- `_NAME_RE = r"^[A-Za-z\s'\-]{1,50}$"`
+- `_USERNAME_RE = r"^[A-Za-z0-9_]{3,20}$"`
+- `_EMAIL_RE = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"`
+
+### `GET|POST /admin`
+Admin login page.
+
+- `GET`: renders `admin.html`.
+- `POST`: blocked if `ADMIN_AUTH_MODE == "entra"`. Calls `AuthService.admin_login`. On success, redirects to `/change_admin_password` if `session['on_login'] == 1`, otherwise to `/admin_panel?active_tab=pending`.
+
+### `GET /admin_panel`
+**Guards:** `check_admin_login`, `check_first_login`
+
+Main admin panel. Reads `page` and `active_tab` query params.
+
+- If `search_term` query param present: calls `SubmissionService.search` → renders with `search_results`. No results → flash + redirect to search tab.
+- Otherwise: calls `AdminService.populate_admin_panel(page, active_tab)` → renders `admin_panel.html`.
+
+Passes `current_user` dict (`username`, `role`, `email`, `user_id`) to the template for self-edit guards.
+
+### `POST /logout`
+Clears session while preserving flash messages (copies `_flashes`, clears session, restores them). Redirects to `/admin` for admin sessions, `/` for user sessions.
+
+### `POST /reject_submission`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Returns:** JSON `{success, message}`
+
+Validates `comments` length ≤ 250. Calls `SubmissionService.reject_request(request_id, comments, actor)`.
+
+### `POST /approve_submission`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Returns:** JSON `{success, message}`
+
+Calls `SubmissionService.approve_request(request_id, actor)`.
+
+### `POST /batch_edit`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Returns:** JSON `{success, message[, errors]}`
+
+Accepts `action` (`approve` or `reject`), `request_ids[]` (list), and optional `comments`. Iterates over IDs and calls the appropriate service method. Collects failures into `errors` dict; returns partial-failure response if any fail.
+
+### `POST /create_admin_account`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Role required:** `super`
+
+In `local`/`both` mode: validates `first_name`, `last_name`, `username` (regex), `email`, `role`. Calls `AdminService.create_admin` then `EmailService.send_welcome_email`.
+
+In `entra` mode: only `email` and `role` are required. `first_name` is set to `"Pending"`, `last_name` to `""`, `username` auto-derived from the email local-part (`re.sub(r'[^A-Za-z0-9_]', '', email.split('@')[0])[:20]`). Sends `EmailService.send_entra_welcome_email` instead.
+
+### `POST /edit_admin_account`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Role required:** `super`
+
+Validates all fields. Blocks self-edit (`user_id_int == session['user_id']`) — admins must use the profile tab to edit their own account. Calls `AdminService.edit_admin`.
+
+### `POST /delete_admin_account`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Role required:** `super`  
+**Returns:** JSON `{success, message}`
+
+Blocks self-delete. Calls `AdminService.delete_admin`.
+
+### `POST /search_submissions`
+**Guards:** `check_admin_login`, `check_first_login`
+
+Redirects to `GET /admin_panel?active_tab=search&search_term=<term>`. Exists to handle the search form as a POST (the actual search logic lives in `GET /admin_panel`).
+
+### `POST /delete_submission`
+**Guards:** `check_admin_login`, `check_first_login`  
+**Returns:** JSON `{success, message, errors}`
+
+Calls `SubmissionService.delete(request_id, actor)`.
+
+### `GET|POST /change_admin_password`
+**Guard:** `check_admin_login`
+
+- Blocked if `ADMIN_AUTH_MODE == "entra"` AND `forgot_password_token` is not in session. (Entra admins cannot set local passwords except via a reset link.)
+- `GET`: renders `change_admin_password.html`. Template shows different fields if `forgot_password_token` is in session (no current-password field).
+- `POST` (normal): verifies current password via `AuthService.compare_password`, checks new/confirm match, calls `AuthService.update_admin_password`.
+- `POST` (forgot-password flow): skips current-password check (token in session proves identity). Calls `AuthService.del_forgot_password_token` after success. Clears session and redirects to `/admin`.
+
+### `GET|POST /forgot_password`
+No auth required. Blocked if `ADMIN_AUTH_MODE == "entra"`.
+
+- `GET` without token: renders `admin_forgot_password.html`.
+- `GET` with `?token=<value>`: calls `AuthService.validate_forgot_password_token`. On success, sets `session['admin_username']` and `session['forgot_password_token']`, redirects to `/change_admin_password`. On failure, flashes and redirects to `/admin`.
+- `POST`: rate-limited by `forgot_password_limiter` (5 req / 5 min per IP). Accepts `identifier` (email or username). Calls `EmailService.send_forgot_password_email`. Always flashes a neutral message regardless of whether the account exists.
+
+### `GET /uploads/<path:filename>`
+**Guard:** `check_admin_login`
+
+Serves uploaded files from `UPLOAD_FOLDER` via `send_from_directory`. The `check_admin_login` guard ensures only authenticated admins can access submitted photos.
+
+---
+
+## OAuth routes (`routes/auth_routes.py`)
+
+Blueprint: `auth`, prefix: `/`
+
+The `oauth` object is a module-level `authlib.integrations.flask_client.OAuth` instance, initialised by `init_oauth(app)` in `create_app()`. The Entra client is registered with the Microsoft OpenID Connect discovery endpoint:
+
+```
+https://login.microsoftonline.com/{ENTRA_TENANT_ID}/v2.0/.well-known/openid-configuration
+```
+
+### `GET /oauth/login`
+
+Query param `flow`: `admin` or `user` (defaults to `user`).
+
+- If `ENTRA_CLIENT_ID` not configured: flash error, redirect to appropriate home.
+- If `flow=admin` and `ADMIN_AUTH_MODE == "local"`: reject.
+- If `flow=user` and `USER_AUTH_MODE == "ldap"`: reject.
+- Otherwise: store `flow` in session, call `oauth.entra.authorize_redirect(callback_url)`.
+
+### `GET /oauth/callback`
+
+- Calls `oauth.entra.authorize_access_token()` — exchanges the auth code for an access token and fetches the ID token userinfo.
+- Pops `session['oauth_flow']` (defaults to `'user'` if missing).
+- `flow == 'admin'`: `AuthService.entra_admin_login(userinfo)` → redirect `/admin_panel` or `/admin`.
+- `flow == 'user'`: `AuthService.entra_user_login(userinfo)` → redirect `/landing` or `/`.
+- Any exception from the token exchange: flash error, redirect `/`.
+
+---
+
+## Error handlers
+
+Registered in `create_app()`:
+
+| Code | Template |
+|---|---|
+| 404 | `404.html` |
+| 500 | `500.html` |
+
+400 (CSRF abort) is handled by Werkzeug's default error response — there is no custom template for it.

--- a/doc/services.md
+++ b/doc/services.md
@@ -1,0 +1,226 @@
+# Services
+
+All services are instantiated in `create_app()` and attached to the Flask `app` object. Routes access them via `current_app.<service_name>`. Services do not import from routes — the dependency graph is strictly one-way.
+
+---
+
+## Database (`db_utils.py`)
+
+```python
+app.db = Database(app)
+```
+
+Thin wrapper around a `psycopg2.ThreadedConnectionPool`.
+
+### `execute_query(query, params=(), fetch_one=False, fetch_all=False, dict_cursor=False)`
+
+Executes a parameterised SQL statement.
+
+| Parameter | Description |
+|---|---|
+| `query` | SQL string with `%s` placeholders |
+| `params` | Tuple of values to bind |
+| `fetch_one` | Return a single row tuple (or `None`) |
+| `fetch_all` | Return a list of row tuples (or `RealDictRow` if `dict_cursor=True`) |
+| `dict_cursor` | Use `psycopg2.extras.RealDictCursor`; rows accessible by column name |
+
+**Return values:**
+- `fetch_one=True` → single row tuple / `None`
+- `fetch_all=True` → list of rows / empty list
+- Neither → `True` on success, `None` on exception
+
+Commits on success, rolls back on any exception, always returns the connection to the pool in the `finally` block.
+
+---
+
+## AuthService (`auth_service.py`)
+
+```python
+app.auth_service = AuthService(app.db)
+```
+
+Handles all credential checking, session population, and password management.
+
+### `admin_login(username, password) → bool`
+
+Authenticates an admin with local credentials. Checks BFA lockout before querying the DB, increments the failure counter on wrong password. Populates session on success.
+
+Requires an active request context (`session`, `request.remote_addr`).
+
+### `entra_admin_login(userinfo: dict) → bool`
+
+Authenticates an admin via Entra ID. Looks up the admin by email (case-insensitive), checks `status`, updates `first_name`/`last_name` from the token if provided, then populates session. Does NOT use BFA — Microsoft handles brute-force on the OAuth side.
+
+Requires an active request context.
+
+### `entra_user_login(userinfo: dict) → bool`
+
+Sets session attrs for an end user authenticated via Entra. Extracts `given_name`, `family_name`, `email`, and `preferred_username` from the ID token. Calls `set_session_attrs`.
+
+### `set_session_attrs(attrs: dict) → bool`
+
+Clears the current session, sets `session.permanent = True`, writes every key/value from `attrs`, and sets `session['user_logged_in'] = True` and `session['attrs'] = attrs`. Returns `True` on success, `False` on exception.
+
+### `update_admin_password(username, new_password) → bool`
+
+Validates password complexity, checks the new password is not the same as the current one, then updates the `admins` table with a new bcrypt hash and resets `on_login` to `0`.
+
+Requires an active request context (uses `flash`).
+
+### `compare_password(username, current_password) → bool`
+
+Fetches the stored bcrypt hash for `username` and checks it against `current_password`. Used by the change-password form to verify the current password before allowing a change.
+
+### `check_bfa(email, ip_address, failed) → bool`
+
+Core brute-force protection. See [algorithms.md — Brute-force lockout](algorithms.md#brute-force-lockout-bfa) for full algorithm description.
+
+- `failed=False`: pre-check (called before credential verification)
+- `failed=True`: post-failure increment (called after a failed credential check)
+
+### `gen_random_forgot_password_link() → (url, token)`
+
+Generates a UUID4 hex token, constructs the reset URL from `FORGOT_PASSWORD_URL` config, returns both. The caller is responsible for storing `_hash_token(token)` in `admin_forgot_password`.
+
+### `validate_forgot_password_token(token) → str | False`
+
+Hashes `token` and queries `admin_forgot_password` joined with `admins` for a non-expired row. Returns the `username` on match, `False` otherwise.
+
+### `del_forgot_password_token(token) → bool`
+
+Deletes the row from `admin_forgot_password` matching the hash of `token`. Called after a successful password reset.
+
+### `_hash_token(token) → str`
+
+Returns `sha256(token.encode()).hexdigest()`. Internal utility used by token storage and lookup.
+
+---
+
+## AdminService (`admin_service.py`)
+
+```python
+app.admin_service = AdminService(app.db)
+```
+
+### `create_admin(first_name, last_name, username, email, role) → bool | None`
+
+Inserts a new row into `admins`. Generates a random 32-byte URL-safe password, hashes it with bcrypt, and stores the hash. The admin cannot log in with local credentials until they go through the welcome-email password-set flow. Returns `True` on success, `None` on DB failure (falsy in either case — callers check `if result`).
+
+### `edit_admin(user_id, first_name, last_name, username, email, role) → bool`
+
+`UPDATE admins SET ... WHERE id = ?`. Returns `True` / `False`.
+
+### `delete_admin(user_id) → bool`
+
+`DELETE FROM admins WHERE id = ?`. Returns `True` / `False`. Self-deletion is prevented at the route layer, not here.
+
+### `populate_admin_panel(page=1, per_page=15, active_tab=None) → dict`
+
+Returns a data dict keyed to match template variables. Uses Python 3.10 `match/case` on `active_tab`.
+
+| `active_tab` | Returns |
+|---|---|
+| `"pending"` | `pending_requests`, `pending_pagination` |
+| `"approved"` | `approved_requests`, `approved_pagination` |
+| `"rejected"` | `rejected_requests`, `rejected_pagination` |
+| `"admins"` | `admins`, `admin_pagination` (super only; `{}` for managers) |
+| anything else | `{"none": None}` |
+
+Pagination dicts have keys: `total_pages`, `next_page` (None on last page), `prev_page` (None on first page). Rows fetched with `dict_cursor=True` so templates can access columns by name.
+
+Requires an active request context (`session["role"]` is read for the admins tab).
+
+---
+
+## SubmissionService (`submission_service.py`)
+
+```python
+app.submission_service = SubmissionService(app.db, app.email_service)
+```
+
+### `create_submission(photo_filepath, license_filepath) → bool`
+
+Reads the current user session for `First Name`, `Last Name`, `ID Number`, `Location`, `Email`. Inserts into `submissions` and stores the returned `request_id` in `session["request_id"]`. Requires an active request context.
+
+### `approve_request(request_id, actor=None) → bool`
+
+Sets `status = 'A'` for the given `request_id`, logs an audit entry, then calls `email_service.send_approved_email`. If the DB update fails, returns `False` without sending email.
+
+### `reject_request(request_id, comments, actor=None) → bool`
+
+Sets `status = 'R'` and `comments = ?` for the given `request_id`, logs an audit entry with the comments, then calls `email_service.send_rejection_email`. Same early-return pattern on DB failure.
+
+### `search(search_term, page=1, per_page=15) → dict | None`
+
+Runs a count query first; returns `None` immediately if count is 0. Otherwise runs the paginated `search_vector @@ plainto_tsquery(?)` query and returns `search_results` + `search_pagination`.
+
+### `delete(request_id, actor=None) → bool`
+
+`DELETE FROM submissions WHERE request_id = ?`. Logs audit entry. Does not delete associated files from the upload volume — those are orphaned. (Future work: clean up on delete.)
+
+---
+
+## LDAPService (`ldap_service.py`)
+
+```python
+app.ldap_service = LDAPService(app.auth_service, app, app.db)
+```
+
+### `search_user(email) → (dn, attrs)`
+
+Binds as the service account, searches for `email` using `LDAP_SEARCH_FILTER` (e.g. `(mail={email})`), returns the DN and a `{display_name: value}` dict built from `LDAP_ATTRIBUTES`. Returns `(None, {})` on failure.
+
+`ldap.filter.filter_format` is used to safely interpolate `email` into the filter string, preventing LDAP injection.
+
+### `auth_user(email, password) → (message, attrs, success)`
+
+Full authentication flow:
+1. BFA pre-check
+2. Duplicate-submission check
+3. `search_user` to get DN
+4. User bind to verify password
+5. BFA failure increment on bind error
+
+Returns a 3-tuple: an optional user-facing message string (or `None`), the attrs dict (or `None`), and a bool success flag.
+
+### `check_user_submissions(email) → bool`
+
+Queries the count of `submissions` with `status IN ('N', 'A')` for the given email. Returns `False` if ≥ 1 exists (blocking the login), `True` otherwise.
+
+### `_start_tls(conn)`
+
+Applies TLS options to an open LDAP connection and calls `start_tls_s()`. Sets `OPT_X_TLS_REQUIRE_CERT = DEMAND` (certificate verification is mandatory), optionally sets a custom CA cert file, and resets the TLS context (`OPT_X_TLS_NEWCTX = 0`).
+
+---
+
+## EmailService (`email_service.py`)
+
+```python
+app.email_service = EmailService(app.db, app)
+```
+
+Uses Flask-Mail. All send methods open a connection with `self.mail.connect()` (a persistent SMTP connection for the duration of the `with` block) and send via that connection. Exceptions are caught and logged; the return value indicates success.
+
+### `send_email_alert() → bool`
+
+Sends two emails on new submission: one to `MAIL_DEFAULT_RECIP` (the admin notification) and one to the submitting user confirming receipt. Reads submission details from the current session. Templates: `email/admin_email.html`, `email/student_email.html`.
+
+### `send_welcome_email(username, first_name, email) → bool`
+
+Sent when a new admin account is created (local auth mode). Generates a password-setup link (24-hour expiry), inserts the hashed token into `admin_forgot_password`, and emails the link. Template: `email/admin_welcome.html`.
+
+### `send_entra_welcome_email(first_name, email) → bool`
+
+Sent when a new admin account is created in Entra mode. No password link is generated — the email just instructs them to sign in with Microsoft. Template: `email/admin_welcome_entra.html`.
+
+### `send_forgot_password_email(**kwargs) → bool`
+
+Accepts either `email=` or `username=` as a keyword argument. Always calls `gen_random_forgot_password_link()` once as a dummy (to normalise timing), then — if the account exists — generates a real token, inserts it, and sends the email. Template: `email/forgot_password.html`.
+
+### `send_approved_email(request_id) → bool`
+
+Looks up `first_name || last_name` and `email` from `submissions` and sends an approval notification. Template: `email/approved_submission.html`.
+
+### `send_rejection_email(request_id, comments) → bool`
+
+Same lookup as above; includes rejection comments in the email. Template: `email/reject_submission.html`.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,143 @@
+# Testing
+
+## Running tests
+
+Tests run inside the Flask container. After a rebuild, pytest is available directly:
+
+```bash
+docker compose exec flask python -m pytest tests/ -v
+```
+
+Without a rebuild, install pytest in the running container first:
+
+```bash
+docker exec flask_test pip install pytest
+docker exec flask_test python -m pytest tests/ -v
+```
+
+Run a single file:
+
+```bash
+docker compose exec flask python -m pytest tests/test_auth_service.py -v
+```
+
+Run a single test:
+
+```bash
+docker compose exec flask python -m pytest tests/test_auth_service.py::test_admin_login_success -v
+```
+
+## Configuration
+
+`app/pytest.ini`:
+
+```ini
+[pytest]
+testpaths = tests
+pythonpath = .
+```
+
+`pythonpath = .` puts `/app` on `sys.path`, enabling top-level imports (`from services.auth_service import AuthService`, etc.) without package installs.
+
+## Architecture
+
+Tests live in `app/tests/`. No real database, LDAP connection, or SMTP server is used — all services are replaced with `unittest.mock.MagicMock` instances.
+
+### `conftest.py`
+
+Defines a `make_app()` factory that creates a minimal Flask app:
+
+- Registers all three blueprints (`admin`, `user`, `auth`)
+- Attaches mock services (`app.db`, `app.auth_service`, `app.admin_service`, `app.ldap_service`, `app.email_service`, `app.submission_service`)
+- Sets required config values with safe test defaults
+- Does **not** register the CSRF `before_request` hook (CSRF is tested independently in `test_csrf_helper.py`)
+- Does **not** call `init_oauth` (OAuth is tested by patching `routes.auth_routes.oauth` directly)
+
+Fixtures provided:
+
+| Fixture | Description |
+|---|---|
+| `app` | Fresh Flask test app per test |
+| `client` | Unauthenticated test client |
+| `admin_client` | Test client with super admin session pre-set |
+| `manager_client` | Test client with manager session pre-set |
+| `user_client` | Test client with end-user session pre-set |
+
+Route tests that need a specific auth mode (e.g. `ADMIN_AUTH_MODE=entra`) use `make_app(ADMIN_AUTH_MODE='entra')` directly.
+
+### Mocking services in route tests
+
+Service mock return values are set per test before calling the route:
+
+```python
+def test_approve_submission_success(app, admin_client):
+    app.submission_service.approve_request.return_value = True
+    resp = admin_client.post('/approve_submission', data={'request_id': '1'})
+    assert resp.get_json()['success'] is True
+```
+
+For routes that render templates, `render_template` is patched at the module level to avoid template rendering errors:
+
+```python
+with patch('routes.admin_routes.render_template', return_value=''):
+    resp = admin_client.get('/admin_panel?active_tab=pending')
+```
+
+### Mocking DB in service tests
+
+Service tests instantiate the service directly with a `MagicMock` DB:
+
+```python
+db = MagicMock()
+svc = AuthService(db=db)
+```
+
+`db.execute_query.return_value` sets a single return value; `db.execute_query.side_effect` sets a list consumed one call at a time. This is necessary when a method makes multiple DB calls in sequence (e.g. `admin_login` calls `check_bfa` which does its own `execute_query`, then the admins SELECT):
+
+```python
+db.execute_query.side_effect = [
+    None,  # check_bfa: no existing BFA record
+    ("First", "Last", "user", "u@e.com", hashed, 1, "super", 0, 42),  # admins SELECT
+]
+```
+
+### Flask context in service tests
+
+Methods that use `session`, `flash`, `request`, or `current_app` require an active request context:
+
+```python
+with app.test_request_context('/'):
+    result = svc.update_admin_password("user", "NewPass1!")
+```
+
+Assertions against `session` must also be inside the context:
+
+```python
+with app.test_request_context('/'):
+    svc.entra_admin_login(userinfo)
+    assert session.get('admin_username') == 'admin'  # ← inside the with block
+```
+
+## Test file index
+
+| File | Component | Tests |
+|---|---|---|
+| `test_utility_helper.py` | `UtilityHelper` | 19 |
+| `test_rate_limiter.py` | `RateLimiter` | 7 |
+| `test_csrf_helper.py` | `generate_csrf_token`, `validate_csrf` | 10 |
+| `test_decorator_helper.py` | `DecoratorHelper` | 9 |
+| `test_auth_service.py` | `AuthService` | 28 |
+| `test_admin_service.py` | `AdminService` | 14 |
+| `test_submission_service.py` | `SubmissionService` | 13 |
+| `test_admin_routes.py` | `admin_routes` blueprint | 47 |
+| `test_user_routes.py` | `user_routes` blueprint | 16 |
+| `test_auth_routes.py` | `auth_routes` blueprint | 13 |
+| **Total** | | **181** |
+
+## Adding new tests
+
+1. Add the test function to the appropriate file, or create a new file prefixed `test_`.
+2. If testing a route that renders a template, patch `render_template` in the relevant module namespace (`routes.admin_routes.render_template`, etc.).
+3. If testing a service method that makes multiple sequential DB calls, use `side_effect` with a list rather than `return_value`.
+4. If the method under test accesses `session`, `flash`, or `request`, wrap the call in `app.test_request_context('/')`.
+5. Rebuild the image (`docker compose build`) or copy the file into the running container (`docker cp`) before running.


### PR DESCRIPTION
Six documents covering architecture, database schema, security
algorithms, service API, HTTP routes, and testing patterns. Intended
to provide enough context for a new developer to understand and extend
the codebase without needing to reverse-engineer from source.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
