### PR TITLE
refactor: eliminate DRY violations across backend, JS, and templates

### DIFF
--- a/app/helpers/utility_helper.py
+++ b/app/helpers/utility_helper.py
@@ -29,6 +29,15 @@ class UtilityHelper:
         return False
 
     @staticmethod
+    def paginate(total, page, per_page) -> dict:
+        total_pages = (total + per_page - 1) // per_page
+        return {
+            "total_pages": total_pages,
+            "next_page":   page + 1 if page < total_pages else None,
+            "prev_page":   page - 1 if page > 1 else None,
+        }
+
+    @staticmethod
     def check_password_complexity(password) -> bool:
         if len(password) > 128:
             flash("Password must be 128 characters or fewer.", "danger")

--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -12,6 +12,32 @@ _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 admin_blueprint = Blueprint("admin", __name__)
 
+
+def _validate_admin_form(first_name, last_name, username, email, role, validate_names=True):
+    if validate_names:
+        if not _NAME_RE.match(first_name):
+            return "First name must be 1–50 letters, spaces, hyphens, or apostrophes."
+        if not _NAME_RE.match(last_name):
+            return "Last name must be 1–50 letters, spaces, hyphens, or apostrophes."
+        if not _USERNAME_RE.match(username):
+            return "Username must be 3–20 alphanumeric characters or underscores."
+    if not _EMAIL_RE.match(email):
+        return "Invalid email address."
+    if role not in _VALID_ROLES:
+        return "Invalid role selected."
+    return None
+
+
+def _parse_user_id(raw):
+    try:
+        return int(raw), None
+    except (TypeError, ValueError):
+        return None, "Invalid user ID."
+
+
+def _json(success, message, **extra):
+    return {"success": success, "message": message, **extra}
+
 @admin_blueprint.route("/admin", methods = ["POST", "GET"])
 def admin():
     if request.method == "POST":
@@ -73,20 +99,9 @@ def create_admin_account():
         first_name = request.form.get("first_name", "").strip()
         last_name = request.form.get("last_name", "").strip()
         username = request.form.get("username", "").strip()
-        if not _NAME_RE.match(first_name):
-            flash("First name must be 1–50 letters, spaces, hyphens, or apostrophes.", "danger")
-            return redirect(url_for("admin.admin_panel", active_tab="admins"))
-        if not _NAME_RE.match(last_name):
-            flash("Last name must be 1–50 letters, spaces, hyphens, or apostrophes.", "danger")
-            return redirect(url_for("admin.admin_panel", active_tab="admins"))
-        if not _USERNAME_RE.match(username):
-            flash("Username must be 3–20 alphanumeric characters or underscores.", "danger")
-            return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if not _EMAIL_RE.match(email):
-        flash("Invalid email address.", "danger")
-        return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if role not in _VALID_ROLES:
-        flash("Invalid role selected.", "danger")
+    error = _validate_admin_form(first_name, last_name, username, email, role, validate_names=not entra_only)
+    if error:
+        flash(error, "danger")
         return redirect(url_for("admin.admin_panel", active_tab="admins"))
 
     if admin_service.create_admin(first_name, last_name, username, email, role):
@@ -127,11 +142,10 @@ def reject_submission():
     request_id = request.form.get("request_id")
     comments = request.form.get("comments", "")
     if len(comments) > _MAX_COMMENT_LEN:
-        return {"success": False, "message": f"Comments must be {_MAX_COMMENT_LEN} characters or fewer."}
+        return _json(False, f"Comments must be {_MAX_COMMENT_LEN} characters or fewer.")
     if submission_service.reject_request(request_id, comments, actor=session.get("admin_username")):
-        return {"success": True, "message": "Submission rejected successfully!"}
-    else:
-        return {"success": False, "message": "Failed to reject submission. Please check logs for more details"}
+        return _json(True, "Submission rejected successfully!")
+    return _json(False, "Failed to reject submission. Please check logs for more details")
 
 @admin_blueprint.route("/approve_submission", methods=["POST"])
 @DecoratorHelper.check_admin_login
@@ -140,9 +154,8 @@ def approve_submission():
     submission_service = current_app.submission_service
     request_id = request.form.get("request_id")
     if submission_service.approve_request(request_id, actor=session.get("admin_username")):
-        return {"success": True, "message": "Submission approved successfully!"}
-    else:
-        return {"success": False, "message": "Failed to approve submission. Please check logs for more details"}
+        return _json(True, "Submission approved successfully!")
+    return _json(False, "Failed to approve submission. Please check logs for more details")
     
 @admin_blueprint.route("/change_admin_password", methods=["POST", "GET"])
 @DecoratorHelper.check_admin_login
@@ -228,17 +241,17 @@ def batch_edit():
             if not submission_service.approve_request(request_id, actor=actor):
                 errors[request_id] = "Failed to approve request"
         if errors:
-            return {"success": False, "message": "Failed to approve one or more requests", "errors": errors}
-        return {"success": True, "message": "All submissions approved successfully!"}
+            return _json(False, "Failed to approve one or more requests", errors=errors)
+        return _json(True, "All submissions approved successfully!")
     elif action == "reject":
         if len(comments) > _MAX_COMMENT_LEN:
-            return {"success": False, "message": f"Comments must be {_MAX_COMMENT_LEN} characters or fewer."}
+            return _json(False, f"Comments must be {_MAX_COMMENT_LEN} characters or fewer.")
         for request_id in request_ids:
             if not submission_service.reject_request(request_id, comments, actor=actor):
                 errors[request_id] = "Failed to reject request"
         if errors:
-            return {"success": False, "message": "Failed to reject one or more requests", "errors": errors}
-        return {"success": True, "message": "All submissions rejected successfully!"}
+            return _json(False, "Failed to reject one or more requests", errors=errors)
+        return _json(True, "All submissions rejected successfully!")
     else:
         flash("Invalid action selected", "danger")
         return redirect(url_for("admin.admin_panel"))
@@ -259,26 +272,14 @@ def edit_admin_account():
     email = request.form.get("email", "").strip()
     role = request.form.get("role", "").strip()
 
-    try:
-        user_id_int = int(user_id)
-    except (TypeError, ValueError):
-        flash("Invalid user ID.", "danger")
+    user_id_int, id_error = _parse_user_id(user_id)
+    if id_error:
+        flash(id_error, "danger")
         return redirect(url_for("admin.admin_panel", active_tab="admins"))
 
-    if not _NAME_RE.match(first_name):
-        flash("First name must be 1–50 letters, spaces, hyphens, or apostrophes.", "danger")
-        return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if not _NAME_RE.match(last_name):
-        flash("Last name must be 1–50 letters, spaces, hyphens, or apostrophes.", "danger")
-        return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if not _USERNAME_RE.match(username):
-        flash("Username must be 3–20 alphanumeric characters or underscores.", "danger")
-        return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if not _EMAIL_RE.match(email):
-        flash("Invalid email address.", "danger")
-        return redirect(url_for("admin.admin_panel", active_tab="admins"))
-    if role not in _VALID_ROLES:
-        flash("Invalid role selected.", "danger")
+    error = _validate_admin_form(first_name, last_name, username, email, role)
+    if error:
+        flash(error, "danger")
         return redirect(url_for("admin.admin_panel", active_tab="admins"))
 
     if user_id_int == session["user_id"]:
@@ -298,20 +299,18 @@ def edit_admin_account():
 def delete_admin_account():
     admin_service = current_app.admin_service
     if session["role"] != "super":
-        return {"success": False, "message": "You do not have permission to delete admin accounts"}
+        return _json(False, "You do not have permission to delete admin accounts")
 
     user_id = request.form.get("user_id", "")
-    try:
-        user_id_int = int(user_id)
-    except (TypeError, ValueError):
-        return {"success": False, "message": "Invalid user ID."}
+    user_id_int, id_error = _parse_user_id(user_id)
+    if id_error:
+        return _json(False, id_error)
     if user_id_int == session["user_id"]:
-        return {"success": False, "message": "You cannot delete your own account"}
+        return _json(False, "You cannot delete your own account")
 
     if admin_service.delete_admin(user_id):
-        return {"success": True, "message": "Admin account deleted successfully!"}
-    else:
-        return {"success": False, "message": "Failed to delete admin account. Please check logs for more details"}
+        return _json(True, "Admin account deleted successfully!")
+    return _json(False, "Failed to delete admin account. Please check logs for more details")
     
 @admin_blueprint.route("/search_submissions", methods=["POST"])
 @DecoratorHelper.check_admin_login
@@ -329,9 +328,8 @@ def delete_submission():
         request_id = request.form.get("request_id")
         submission_service = current_app.submission_service
         if submission_service.delete(request_id, actor=session.get("admin_username")):
-            return {"success": True, "message": f"Deleted submission with id: {request_id} succesfully", "errors": None}
-        else:
-            return {"success": False, "message": f"Failed to delete submission id: {request_id}", "errors": "err"}
+            return _json(True, f"Deleted submission with id: {request_id} succesfully", errors=None)
+        return _json(False, f"Failed to delete submission id: {request_id}", errors="err")
 
 @admin_blueprint.route("/uploads/<path:filename>")
 @DecoratorHelper.check_admin_login

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1,6 +1,6 @@
 import bcrypt
 import secrets
-from flask import session, flash
+from flask import session
 from factories import get_logger
 from helpers import UtilityHelper
 
@@ -30,98 +30,57 @@ class AdminService:
         match active_tab:
             case "admins":
                 row = self.db.execute_query("select count(*) from admins", fetch_one=True)
-                total_admins = row[0]
-                admin_pages = (total_admins + per_page - 1) // per_page
-                admin_prev_page = page - 1 if page > 1 else None
-                admin_next_page = page + 1 if page < admin_pages else None
-                
                 if session["role"] == "super":
-                    rows = self.db.execute_query("select first_name || ' ' || last_name as full_name, email, username, role, id from admins order by id limit %s offset %s",
-                                        (per_page, offset),
-                                        fetch_all=True, dict_cursor=True)
-
-                    admins = [row for row in rows]
-
+                    rows = self.db.execute_query(
+                        "select first_name || ' ' || last_name as full_name, email, username, role, id from admins order by id limit %s offset %s",
+                        (per_page, offset), fetch_all=True, dict_cursor=True)
                     return {
-                        "admins" : admins,
-                        "admin_pagination": {
-                            "total_pages" : admin_pages,
-                            "next_page" : admin_next_page,
-                            "prev_page" : admin_prev_page
-                        }
+                        "admins": list(rows),
+                        "admin_pagination": UtilityHelper.paginate(row[0], page, per_page),
                     }
                 return {}
-                        
+
             case "pending":
                 row = self.db.execute_query("select count(*) from submissions where status='N'", fetch_one=True)
-                total_pending = row[0]
-                pending_pages = (total_pending + per_page - 1) // per_page
-                pending_previous_page = page - 1 if page > 1 else None
-                pending_next_page = page + 1 if page < pending_pages else None
-                
-                rows = self.db.execute_query("""select first_name || ' ' || last_name as full_name, email, id_number, location, 
-                            to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
-                            photo_filepath, license_filepath, request_id
-                            from submissions where status='N' order by request_id limit %s offset %s""", (per_page, offset), fetch_all=True, dict_cursor=True)
-                
-                pending_requests = [row for row in rows]
-
+                rows = self.db.execute_query(
+                    """select first_name || ' ' || last_name as full_name, email, id_number, location,
+                        to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
+                        photo_filepath, license_filepath, request_id
+                        from submissions where status='N' order by request_id limit %s offset %s""",
+                    (per_page, offset), fetch_all=True, dict_cursor=True)
                 return {
-                    "pending_requests" : pending_requests,
-                    "pending_pagination": {
-                        "total_pages" : pending_pages,
-                        "next_page" : pending_next_page,
-                        "prev_page" : pending_previous_page
-                    }
+                    "pending_requests": list(rows),
+                    "pending_pagination": UtilityHelper.paginate(row[0], page, per_page),
                 }
 
             case "rejected":
                 row = self.db.execute_query("select count(*) from submissions where status='R'", fetch_one=True)
-                total_rejected = row[0]
-                rejected_pages = (total_rejected + per_page - 1) // per_page
-                rejected_previous_page = page - 1 if page > 1 else None
-                rejected_next_page = page + 1 if page < rejected_pages else None
-
-                rows = self.db.execute_query("""select first_name || ' ' || last_name as full_name, email, id_number, location, 
-                            to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
-                            photo_filepath, license_filepath, comments, request_id
-                            from submissions where status='R' order by request_id limit %s offset %s""", (per_page, offset), fetch_all=True, dict_cursor=True)
-                
-                rejected_requests = [row for row in rows]
-
+                rows = self.db.execute_query(
+                    """select first_name || ' ' || last_name as full_name, email, id_number, location,
+                        to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
+                        photo_filepath, license_filepath, comments, request_id
+                        from submissions where status='R' order by request_id limit %s offset %s""",
+                    (per_page, offset), fetch_all=True, dict_cursor=True)
                 return {
-                    "rejected_requests" : rejected_requests,
-                    "rejected_pagination": {
-                        "total_pages" : rejected_pages,
-                        "next_page" : rejected_next_page,
-                        "prev_page" : rejected_previous_page
-                    }
+                    "rejected_requests": list(rows),
+                    "rejected_pagination": UtilityHelper.paginate(row[0], page, per_page),
                 }
-        
+
             case "approved":
                 row = self.db.execute_query("select count(*) from submissions where status='A'", fetch_one=True)
-                total_approved = row[0]
-                approved_pages = (total_approved + per_page - 1) // per_page
-                approved_previous_page = page - 1 if page > 1 else None
-                approved_next_page = page + 1 if page < approved_pages else None
-
-                rows = self.db.execute_query("""select first_name || ' ' || last_name as full_name, email, id_number, location, 
-                            to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
-                            photo_filepath, license_filepath, request_id
-                            from submissions where status='A' order by request_id limit %s offset %s""", (per_page, offset), fetch_all=True, dict_cursor=True)
-                
-                approved_requests = [row for row in rows]
-
+                rows = self.db.execute_query(
+                    """select first_name || ' ' || last_name as full_name, email, id_number, location,
+                        to_char(timestamp_inserted, 'yyyy-mm-dd hh12:mi:ss AM') as timestamp_inserted,
+                        photo_filepath, license_filepath, request_id
+                        from submissions where status='A' order by request_id limit %s offset %s""",
+                    (per_page, offset), fetch_all=True, dict_cursor=True)
                 return {
-                    "approved_requests" : approved_requests,
-                    "approved_pagination": {
-                        "total_pages" : approved_pages,
-                        "next_page" : approved_next_page,
-                        "prev_page" : approved_previous_page
-                    }
+                    "approved_requests": list(rows),
+                    "approved_pagination": UtilityHelper.paginate(row[0], page, per_page),
                 }
+
             case _:
-                return {"none":None}
+                return {"none": None}
     
 
     def edit_admin(self, user_id, first_name, last_name, username, email, role) -> bool:

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -31,20 +31,26 @@ class AuthService:
                 self.logger.warning(f"[{request.remote_addr}] login failed for user: {username} - Incorrect password")
                 self.check_bfa(username, request.remote_addr, True)
                 return False
-            session.clear()
-            session.permanent = True
-            session["first_name"] = row[0]
-            session["last_name"] = row[1]
-            session["admin_username"] = row[2]
-            session["email"] = row[3]
-            session["role"] = row[6]
-            session["on_login"] = row[7]
-            session["user_id"] = row[8]
+            self._set_admin_session(row[0], row[1], row[2], row[3], row[6], row[7], row[8])
             self.logger.info(f"[{request.remote_addr}] login successful for user: {username}")
             return True
         else:
             return False
     
+    def _set_admin_session(self, first_name, last_name, username, email, role, on_login, user_id):
+        session.clear()
+        session.permanent = True
+        session["first_name"]     = first_name
+        session["last_name"]      = last_name
+        session["admin_username"] = username
+        session["email"]          = email
+        session["role"]           = role
+        session["on_login"]       = on_login
+        session["user_id"]        = user_id
+
+    def _fetch_admin_password(self, username):
+        return self.db.execute_query("select password from admins where username=%s", (username,), fetch_one=True)
+
     def update_admin_password(self, username, new_password) -> bool:
         self.logger.info(f"{username} attempting to change password.")
         if not UtilityHelper.check_password_complexity(new_password):
@@ -52,7 +58,7 @@ class AuthService:
         new_password = new_password.encode('utf-8')
         salt = bcrypt.gensalt()
         hashed_password = bcrypt.hashpw(new_password, salt).decode("utf-8")
-        row = self.db.execute_query("select password from admins where username=%s", (username,), fetch_one=True)
+        row = self._fetch_admin_password(username)
         if not row:
             self.logger.error(f"{username} not found in admins table.")
             return False
@@ -70,7 +76,7 @@ class AuthService:
         return True
     
     def compare_password(self, username, current_password) -> bool:
-        row = self.db.execute_query("select password from admins where username=%s", (username,), fetch_one=True)
+        row = self._fetch_admin_password(username)
         if not row:
             self.logger.warning(f"{username} not found in admins, unable to compare passwords.")
             return False
@@ -148,15 +154,7 @@ class AuthService:
                 (given_name or row[0], family_name or row[1], row[7])
             )
 
-        session.clear()
-        session.permanent = True
-        session["first_name"]     = given_name  or row[0]
-        session["last_name"]      = family_name or row[1]
-        session["admin_username"] = row[2]
-        session["email"]          = row[3]
-        session["role"]           = row[5]
-        session["on_login"]       = 0
-        session["user_id"]        = row[7]
+        self._set_admin_session(given_name or row[0], family_name or row[1], row[2], row[3], row[5], 0, row[7])
         self.logger.info(f"Entra admin login successful for: {email}")
         return True
 

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -12,6 +12,18 @@ class EmailService:
         self.logger = get_logger("email_service")
         self.logger.info("EmailService initialized")
 
+    def _send(self, subject, recipients, template, **ctx) -> bool:
+        html_body = render_template(template, **ctx)
+        msg = Message(subject=subject, recipients=recipients, html=html_body)
+        try:
+            with self.mail.connect() as conn:
+                conn.send(msg)
+        except Exception:
+            self.logger.exception(f"Error sending '{subject}' to {recipients}")
+            return False
+        self.logger.info(f"Sent '{subject}' to {recipients}")
+        return True
+
     def send_email_alert(self) -> bool:
         messages = []
         request_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -66,35 +78,11 @@ class EmailService:
         if not result:
             self.logger.error(f"Could not insert setup token for new admin {username}.")
             return False
-        html_body = render_template('email/admin_welcome.html',
-                                    username=username,
-                                    first_name=first_name,
-                                    url=url)
-        msg = Message(subject="Welcome to IDPortal!",
-                    recipients=[email],
-                    html=html_body)
-        try:
-            with self.mail.connect() as conn:
-                conn.send(msg)
-        except Exception:
-            self.logger.exception("Error occurred while trying to send the welcome email!")
-            return False
-        self.logger.info(f"Succesfully sent welcome email to {email}")
-        return True
+        return self._send("Welcome to IDPortal!", [email], 'email/admin_welcome.html',
+                          username=username, first_name=first_name, url=url)
     
     def send_entra_welcome_email(self, first_name, email) -> bool:
-        html_body = render_template('email/admin_welcome_entra.html', first_name=first_name)
-        msg = Message(subject="Welcome to IDPortal!",
-                      recipients=[email],
-                      html=html_body)
-        try:
-            with self.mail.connect() as conn:
-                conn.send(msg)
-        except Exception:
-            self.logger.exception("Error sending Entra welcome email!")
-            return False
-        self.logger.info(f"Sent Entra welcome email to {email}")
-        return True
+        return self._send("Welcome to IDPortal!", [email], 'email/admin_welcome_entra.html', first_name=first_name)
 
     def send_forgot_password_email(self, **kwargs) -> bool:
         auth_service = self.app.auth_service
@@ -118,21 +106,8 @@ class EmailService:
         if not result:
             return False
 
-        html_body = render_template('email/forgot_password.html',
-                                    full_name=full_name,
-                                    username=username,
-                                    url=url)
-        msg = Message(subject="Forgot Password Request",
-                        recipients=[email],
-                        html=html_body)
-        try:
-            with self.mail.connect() as conn:
-                conn.send(msg)
-        except Exception:
-            self.logger.exception("Error occured while trying to send forgot password email!")
-            return False
-        self.logger.info(f"Succesfully sent forgot password email to {kwargs}")
-        return True
+        return self._send("Forgot Password Request", [email], 'email/forgot_password.html',
+                          full_name=full_name, username=username, url=url)
     
     def send_approved_email(self, request_id) -> bool:
         row = self.db.execute_query("select first_name || ' ' || last_name, email from submissions where request_id=%s", (request_id,), fetch_one=True)
@@ -143,17 +118,8 @@ class EmailService:
         name = row[0]
         email = row[1]
 
-        html_body = render_template("email/approved_submission.html", student_name=name)
-        msg = Message(subject="Your ID submission has been approved!", recipients=[email], html=html_body)
-
-        try:
-            with self.mail.connect() as conn:
-                conn.send(msg)
-        except Exception:
-            self.logger.exception("An email error has occurred!")
-            return False
-        self.logger.info(f"Submission notification succesfully sent to {email}")
-        return True
+        return self._send("Your ID submission has been approved!", [email],
+                          "email/approved_submission.html", student_name=name)
     
     def send_rejection_email(self, request_id, comments):
         row = self.db.execute_query("select first_name || ' ' || last_name, email from submissions where request_id=%s", (request_id,), fetch_one=True)
@@ -164,14 +130,5 @@ class EmailService:
         name = row[0]
         email = row[1]
 
-        html_body = render_template("email/reject_submission.html", student_name=name, REJECTION_COMMENTS=comments)
-        msg = Message(subject="Your ID submission has been rejected!", recipients=[email], html=html_body)
-
-        try:
-            with self.mail.connect() as conn:
-                conn.send(msg)
-        except Exception:
-            self.logger.exception("An email error has occurred!")
-            return False
-        self.logger.info(f"Submission notification succesfully sent to {email}")
-        return True
+        return self._send("Your ID submission has been rejected!", [email],
+                          "email/reject_submission.html", student_name=name, REJECTION_COMMENTS=comments)

--- a/app/services/submission_service.py
+++ b/app/services/submission_service.py
@@ -1,5 +1,6 @@
-from flask import session, flash
+from flask import session
 from factories import get_logger
+from helpers import UtilityHelper
 
 class SubmissionService:
     def __init__(self, db=None, mail=None):
@@ -56,14 +57,9 @@ class SubmissionService:
         rows = self.db.execute_query(
             "SELECT * FROM submissions WHERE search_vector @@ plainto_tsquery(%s) ORDER BY request_id LIMIT %s OFFSET %s",
             (search_term, per_page, offset), fetch_all=True, dict_cursor=True)
-        total_pages = (total + per_page - 1) // per_page
         return {
-            "search_results": [row for row in rows],
-            "search_pagination": {
-                "total_pages": total_pages,
-                "next_page": page + 1 if page < total_pages else None,
-                "prev_page": page - 1 if page > 1 else None
-            }
+            "search_results": list(rows),
+            "search_pagination": UtilityHelper.paginate(total, page, per_page),
         }
 
     def delete(self, request_id, actor=None) -> bool:

--- a/app/static/js/admin_panel.js
+++ b/app/static/js/admin_panel.js
@@ -21,459 +21,325 @@ function showResultModal(success, message, errors = {}) {
     return;
   }
 
-  // Update modal title and message
   modalTitle.textContent = success ? "Success" : "Error";
   modalBody.textContent = message;
 
-  // Update modal errors if any
   if (Object.keys(errors).length > 0) {
     const errorList = Object.entries(errors)
       .map(([id, error]) => `<li>Request ID ${escapeHtml(id)}: ${escapeHtml(error)}</li>`)
       .join('');
     modalErrors.innerHTML = `<ul>${errorList}</ul>`;
   } else {
-    modalErrors.innerHTML = ''; // Clear errors if none
+    modalErrors.innerHTML = '';
   }
 
-  // Show the modal
   bootstrap.Modal.getOrCreateInstance(document.getElementById('resultModal')).show();
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function postAction(url, formData) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
+    body: formData,
+  }).then(r => r.json());
+}
 
-  function setBulkRequestIds(ids) {
-    const container = document.getElementById('bulkRequestIdsContainer');
-    container.innerHTML = '';
-    ids.forEach(function (id) {
-      const input = document.createElement('input');
-      input.type = 'hidden';
-      input.name = 'request_ids';
-      input.value = id;
-      container.appendChild(input);
+function buildRejectForm(showCounter) {
+  return `
+    <form id="rejectForm">
+      <div class="mb-3">
+        <label for="rejectReason" class="form-label">Rejection Comments (max 250 characters)</label>
+        <textarea class="form-control" id="rejectReason" name="rejectReason" rows="4" maxlength="250" placeholder="Enter rejection comments..."></textarea>
+        ${showCounter ? '<small id="rejectReasonCount" class="form-text text-muted">0/250 characters</small>' : ''}
+      </div>
+    </form>
+  `;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Shared modal element references
+  const rejectModal          = document.getElementById('rejectModal');
+  const rejectModalBody      = document.getElementById('rejectModalBody');
+  const rejectConfirmBtn     = document.getElementById('rejectConfirmBtn');
+  const photoModal           = document.getElementById('photoModal');
+  const photoModalBody       = document.getElementById('photoModalBody');
+  const resultModal          = document.getElementById('resultModal');
+  const commentsModal        = document.getElementById('commentsModal');
+  const commentsModalBody    = document.getElementById('commentsModalBody');
+  const createAdminModal     = document.getElementById('createAdminModal');
+  const createAdminModalBody = document.getElementById('createAdminModalBody');
+  const editAdminModal       = document.getElementById('editAdminModal');
+  const editAdminModalBody   = document.getElementById('editAdminModalBody');
+  const deleteAdminModal     = document.getElementById('deleteAdminModal');
+  const deleteAdminModalBody = document.getElementById('deleteAdminModalBody');
+  const deleteSubmissionModal     = document.getElementById('deleteSubmissionModal');
+  const deleteSubmissionModalBody = document.getElementById('deleteSubmissionModalBody');
+
+  // ── Select-all / row highlight / button toggle ────────────────────────────
+
+  const selectAll   = document.getElementById('selectAllPending');
+  const checkboxes  = document.querySelectorAll('.pending-checkbox');
+  const cbRows      = Array.from(checkboxes).map(cb => cb.closest('tr'));
+  const actionsHeader = document.querySelector('thead th:last-child');
+
+  function updateRowHighlight() {
+    checkboxes.forEach((cb, i) => {
+      cbRows[i]?.classList.toggle('table-active', cb.checked);
     });
   }
 
-  // Approve Selected
-  document.getElementById('approveSelectedBtn').addEventListener('click', function (e) {
-    e.preventDefault();
-    const ids = Array.from(document.querySelectorAll('.pending-checkbox:checked')).map(cb => cb.value);
-    if (ids.length === 0) {
-      alert('No requests selected.');
-      return;
-    }
-
-    const formData = new FormData();
-    formData.append('action', 'approve');
-    ids.forEach(id => formData.append('request_ids', id));
-
-    fetch(batchEditUrl, {
-      method: 'POST',
-      headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
-      body: formData
-    })
-      .then(response => response.json())
-      .then(data => {
-        showResultModal(data.success, data.message, data.errors || {});
-      })
-      .catch(() => {
-        showResultModal(false, 'An error occurred while approving the submissions.');
-      });
-  });
-
-  // Reject Selected
-  document.getElementById('rejectSelectedBtn').addEventListener('click', function (e) {
-    e.preventDefault();
-    const ids = Array.from(document.querySelectorAll('.pending-checkbox:checked')).map(cb => cb.value);
-    if (ids.length === 0) {
-      alert('No requests selected.');
-      return;
-    }
-
-    // Populate the modal body with the rejection comments text box
-    rejectModalBody.innerHTML = `
-      <form id="rejectForm">
-        <div class="mb-3">
-          <label for="rejectReason" class="form-label">Rejection Comments (max 250 characters)</label>
-          <textarea class="form-control" id="rejectReason" name="rejectReason" rows="4" maxlength="250" placeholder="Enter rejection comments..."></textarea>
-        </div>
-      </form>
-    `;
-
-    // Show the modal
-    const modalInstance = bootstrap.Modal.getOrCreateInstance(rejectModal);
-    modalInstance.show();
-
-    // Handle confirmation
-    rejectConfirmBtn.onclick = function () {
-      const rejectReasonInput = document.getElementById('rejectReason');
-      const comments = rejectReasonInput.value.trim();
-      if (comments.length === 0) {
-        alert('Please enter rejection comments.');
-        return;
+  function toggleRowButtons() {
+    const anySelected = Array.from(checkboxes).some(cb => cb.checked);
+    document.querySelectorAll('tbody tr').forEach(row => {
+      const approveBtn = row.querySelector('.btn-success[data-request-id]');
+      const rejectBtn  = row.querySelector('.btn-danger[data-request-id]');
+      if (approveBtn && rejectBtn) {
+        approveBtn.style.display = anySelected ? 'none' : '';
+        rejectBtn.style.display  = anySelected ? 'none' : '';
       }
+    });
+    if (actionsHeader) actionsHeader.style.display = anySelected ? 'none' : '';
+  }
 
-      const formData = new FormData();
-      formData.append('action', 'reject');
-      ids.forEach(id => formData.append('request_ids', id));
-      formData.append('comments', comments);
-
-      fetch(batchEditUrl, {
-        method: 'POST',
-        headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
-        body: formData
-      })
-        .then(response => response.json())
-        .then(data => {
-          showResultModal(data.success, data.message, data.errors || {});
-          modalInstance.hide(); // Close the modal after submission
-        })
-        .catch(() => {
-          showResultModal(false, 'An error occurred while rejecting the submissions.');
-          modalInstance.hide(); // Close the modal after submission
-        });
-    };
+  if (selectAll) {
+    selectAll.addEventListener('change', function () {
+      checkboxes.forEach(cb => { cb.checked = selectAll.checked; });
+      updateRowHighlight();
+      toggleRowButtons();
+    });
+  }
+  checkboxes.forEach(cb => {
+    cb.addEventListener('change', () => { updateRowHighlight(); toggleRowButtons(); });
   });
 
-  // Approve Single Submission
+  // ── Bulk approve ─────────────────────────────────────────────────────────
+
+  const approveSelectedBtn = document.getElementById('approveSelectedBtn');
+  if (approveSelectedBtn) {
+    approveSelectedBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      const ids = Array.from(document.querySelectorAll('.pending-checkbox:checked')).map(cb => cb.value);
+      if (!ids.length) { alert('No requests selected.'); return; }
+      const formData = new FormData();
+      formData.append('action', 'approve');
+      ids.forEach(id => formData.append('request_ids', id));
+      postAction(batchEditUrl, formData)
+        .then(data => showResultModal(data.success, data.message, data.errors || {}))
+        .catch(() => showResultModal(false, 'An error occurred while approving the submissions.'));
+    });
+  }
+
+  // ── Bulk reject ──────────────────────────────────────────────────────────
+
+  const rejectSelectedBtn = document.getElementById('rejectSelectedBtn');
+  if (rejectSelectedBtn) {
+    rejectSelectedBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      const ids = Array.from(document.querySelectorAll('.pending-checkbox:checked')).map(cb => cb.value);
+      if (!ids.length) { alert('No requests selected.'); return; }
+      rejectModalBody.innerHTML = buildRejectForm(false);
+      const modalInstance = bootstrap.Modal.getOrCreateInstance(rejectModal);
+      modalInstance.show();
+      rejectConfirmBtn.onclick = function () {
+        const comments = document.getElementById('rejectReason').value.trim();
+        if (!comments) { alert('Please enter rejection comments.'); return; }
+        const formData = new FormData();
+        formData.append('action', 'reject');
+        ids.forEach(id => formData.append('request_ids', id));
+        formData.append('comments', comments);
+        postAction(batchEditUrl, formData)
+          .then(data => showResultModal(data.success, data.message, data.errors || {}))
+          .catch(() => showResultModal(false, 'An error occurred while rejecting the submissions.'))
+          .finally(() => modalInstance.hide());
+      };
+    });
+  }
+
+  // ── Single approve ───────────────────────────────────────────────────────
+
   document.querySelectorAll('.btn-success[data-request-id]').forEach(button => {
     button.addEventListener('click', function () {
-      const requestId = this.getAttribute('data-request-id'); // Get the request ID from the button
       const formData = new FormData();
-      formData.append('request_id', requestId);
-
-      fetch(approveUrl, {
-        method: 'POST',
-        headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
-        body: formData
-      })
-        .then(response => response.json())
-        .then(data => {
-          showResultModal(data.success, data.message, data.errors || {});
-        })
-        .catch(() => {
-          showResultModal(false, 'An error occurred while approving the submission.');
-        });
+      formData.append('request_id', this.getAttribute('data-request-id'));
+      postAction(approveUrl, formData)
+        .then(data => showResultModal(data.success, data.message, data.errors || {}))
+        .catch(() => showResultModal(false, 'An error occurred while approving the submission.'));
     });
   });
 
-  // Reject Single Submission
+  // ── Single reject ────────────────────────────────────────────────────────
+
   document.querySelectorAll('.btn-danger[data-request-id]').forEach(button => {
     button.addEventListener('click', function () {
-      const requestId = this.getAttribute('data-request-id'); // Get the request ID from the button
-
-      // Populate the modal body with the rejection comments text box and live character count
-      const rejectModal = document.getElementById('rejectModal');
-      const rejectModalBody = document.getElementById('rejectModalBody');
-      const rejectConfirmBtn = document.getElementById('rejectConfirmBtn');
-
-      rejectModalBody.innerHTML = `
-        <form id="rejectForm">
-          <div class="mb-3">
-            <label for="rejectReason" class="form-label">Rejection Comments (max 250 characters)</label>
-            <textarea class="form-control" id="rejectReason" name="rejectReason" rows="4" maxlength="250" placeholder="Enter rejection comments..."></textarea>
-            <small id="rejectReasonCount" class="form-text text-muted">0/250 characters</small>
-          </div>
-        </form>
-      `;
-
-      // Show the modal
+      const requestId = this.getAttribute('data-request-id');
+      rejectModalBody.innerHTML = buildRejectForm(true);
       const modalInstance = bootstrap.Modal.getOrCreateInstance(rejectModal);
       modalInstance.show();
-
-      // Handle live character count
       const rejectReasonInput = document.getElementById('rejectReason');
       const rejectReasonCount = document.getElementById('rejectReasonCount');
-
       rejectReasonInput.addEventListener('input', function () {
-        const currentLength = rejectReasonInput.value.length;
-        rejectReasonCount.textContent = `${currentLength}/250 characters`;
+        rejectReasonCount.textContent = `${rejectReasonInput.value.length}/250 characters`;
       });
-
-      // Handle confirmation
       rejectConfirmBtn.onclick = function () {
         const comments = rejectReasonInput.value.trim();
-        if (comments.length === 0) {
-          alert('Please enter rejection comments.');
-          return;
-        }
-
+        if (!comments) { alert('Please enter rejection comments.'); return; }
         const formData = new FormData();
         formData.append('request_id', requestId);
         formData.append('comments', comments);
-
-        fetch(rejectUrl, {
-          method: 'POST',
-          headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
-          body: formData
-        })
-          .then(response => response.json())
-          .then(data => {
-            showResultModal(data.success, data.message, data.errors || {});
-            modalInstance.hide(); // Close the modal after submission
-          })
-          .catch(() => {
-            showResultModal(false, 'An error occurred while rejecting the submission.');
-            modalInstance.hide(); // Close the modal after submission
-          });
+        postAction(rejectUrl, formData)
+          .then(data => showResultModal(data.success, data.message, data.errors || {}))
+          .catch(() => showResultModal(false, 'An error occurred while rejecting the submission.'))
+          .finally(() => modalInstance.hide());
       };
     });
   });
-});
 
-document.addEventListener('DOMContentLoaded', function () {
-    const photoModal = document.getElementById('photoModal');
-    const photoModalBody = document.getElementById('photoModalBody');
+  // ── Photo modal ──────────────────────────────────────────────────────────
 
+  if (photoModal) {
     photoModal.addEventListener('show.bs.modal', function (event) {
-        const button = event.relatedTarget; // Button that triggered the modal
-        const userPhotoUrl = button.getAttribute('data-photo-user');
-        const licensePhotoUrl = button.getAttribute('data-photo-license');
-
-        // Update the modal body with the photos, centered
-        photoModalBody.innerHTML = `
-            <div class="mb-3 text-center">
-                <div class="fw-bold mb-1">User Photo</div>
-                <img src="${escapeHtml(userPhotoUrl)}" alt="User Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
-            </div>
-            <div class="text-center">
-                <div class="fw-bold mb-1">Driver's License</div>
-                <img src="${escapeHtml(licensePhotoUrl)}" alt="License Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
-            </div>
-        `;
+      const btn = event.relatedTarget;
+      photoModalBody.innerHTML = `
+        <div class="mb-3 text-center">
+          <div class="fw-bold mb-1">User Photo</div>
+          <img src="${escapeHtml(btn.getAttribute('data-photo-user'))}" alt="User Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
+        </div>
+        <div class="text-center">
+          <div class="fw-bold mb-1">Driver's License</div>
+          <img src="${escapeHtml(btn.getAttribute('data-photo-license'))}" alt="License Photo" class="img-fluid d-block mx-auto" style="max-height:200px;">
+        </div>
+      `;
     });
-});
+  }
 
-document.addEventListener('DOMContentLoaded', function() {
-    const selectAll = document.getElementById('selectAllPending');
-    const checkboxes = document.querySelectorAll('.pending-checkbox');
-    const rows = Array.from(checkboxes).map(cb => cb.closest('tr'));
-
-    function updateRowHighlight() {
-      checkboxes.forEach((cb, i) => {
-        if (cb.checked) {
-          rows[i].classList.add('table-active');
-        } else {
-          rows[i].classList.remove('table-active');
-        }
-      });
-    }
-
-    if (selectAll) {
-      selectAll.addEventListener('change', function() {
-        checkboxes.forEach(cb => { cb.checked = selectAll.checked; });
-        updateRowHighlight();
-      });
-    }
-
-    checkboxes.forEach((cb, i) => {
-      cb.addEventListener('change', updateRowHighlight);
-    });
-});
-
-document.addEventListener('DOMContentLoaded', function () {
-  const resultModal = document.getElementById('resultModal');
+  // ── Result modal — reload page on close ──────────────────────────────────
 
   if (resultModal) {
     resultModal.addEventListener('hide.bs.modal', function () {
-      // Refresh the current page
       window.location.reload();
     });
   }
-});
 
-document.addEventListener('DOMContentLoaded', function () {
-  const commentsModal = document.getElementById('commentsModal');
-  const commentsModalBody = document.getElementById('commentsModalBody');
+  // ── Comments modal ───────────────────────────────────────────────────────
 
-  // Handle "View Comments" button click
   document.querySelectorAll('.btn-warning[data-comments]').forEach(button => {
     button.addEventListener('click', function () {
-      const comments = this.getAttribute('data-comments');
-
       const label = document.createElement('label');
       label.className = 'form-label';
       label.textContent = 'Rejection Comments';
-
       const textarea = document.createElement('textarea');
       textarea.className = 'form-control';
       textarea.rows = 4;
       textarea.readOnly = true;
-      textarea.textContent = comments;
-
+      textarea.textContent = this.getAttribute('data-comments');
       const wrapper = document.createElement('div');
       wrapper.className = 'mb-3';
       wrapper.appendChild(label);
       wrapper.appendChild(textarea);
-
       commentsModalBody.innerHTML = '';
       commentsModalBody.appendChild(wrapper);
-
       bootstrap.Modal.getOrCreateInstance(commentsModal).show();
     });
   });
-});
 
-document.addEventListener('DOMContentLoaded', function () {
-  const checkboxes = document.querySelectorAll('.pending-checkbox');
-  const rows = document.querySelectorAll('tbody tr');
-  const actionsHeader = document.querySelector('thead th:last-child'); // Select the "Actions" header
+  // ── Create admin modal ───────────────────────────────────────────────────
 
-  function toggleRowButtons() {
-    const anySelected = Array.from(checkboxes).some(checkbox => checkbox.checked);
-
-    rows.forEach(row => {
-      const approveButton = row.querySelector('.btn-success[data-request-id]');
-      const rejectButton = row.querySelector('.btn-danger[data-request-id]');
-
-      if (approveButton && rejectButton) {
-        approveButton.style.display = anySelected ? 'none' : '';
-        rejectButton.style.display = anySelected ? 'none' : '';
-      }
+  const createAdminBtn = document.getElementById('createAdminBtn');
+  if (createAdminBtn) {
+    createAdminBtn.addEventListener('click', function () {
+      const authMode    = _cfg.adminAuthMode;
+      const entraOnly   = authMode === 'entra';
+      const entraEnabled = authMode === 'entra' || authMode === 'both';
+      createAdminModalBody.innerHTML = `
+        <form id="createAdminForm" method="POST" action="/create_admin_account">
+          <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
+          ${entraEnabled ? `<div class="alert alert-info d-flex align-items-center gap-2 py-2 mb-3">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>
+            ${entraOnly ? 'This admin will sign in with their Microsoft account. Name will be populated on first login.' : 'This admin can sign in with Microsoft or their local credentials.'}
+          </div>` : ''}
+          ${entraOnly ? '' : `<div class="mb-3">
+            <label for="firstName" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="firstName" name="first_name" required>
+          </div>
+          <div class="mb-3">
+            <label for="lastName" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="lastName" name="last_name" required>
+          </div>
+          <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+          </div>`}
+          <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+          </div>
+          <div class="mb-3">
+            <label for="role" class="form-label">Role</label>
+            <select class="form-select" id="role" name="role" required>
+              <option value="manager">Manager</option>
+              <option value="super">Super</option>
+            </select>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Create</button>
+          </div>
+        </form>
+      `;
+      bootstrap.Modal.getOrCreateInstance(createAdminModal).show();
     });
-
-    // Toggle visibility of the "Actions" header
-    if (actionsHeader) {
-      actionsHeader.style.display = anySelected ? 'none' : '';
-    }
   }
 
-  // Add event listeners to checkboxes
-  checkboxes.forEach(checkbox => {
-    checkbox.addEventListener('change', toggleRowButtons);
-  });
+  // ── Edit admin modal ─────────────────────────────────────────────────────
 
-  // Add event listener to "Select All" checkbox
-  const selectAllCheckbox = document.getElementById('selectAllPending');
-  if (selectAllCheckbox) {
-    selectAllCheckbox.addEventListener('change', function () {
-      checkboxes.forEach(checkbox => {
-        checkbox.checked = selectAllCheckbox.checked;
-      });
-      toggleRowButtons();
-    });
-  }
-});
-
-document.addEventListener('DOMContentLoaded', function () {
-  const createAdminModal = document.getElementById('createAdminModal');
-  const createAdminModalBody = document.getElementById('createAdminModalBody');
-
-  // Open Create Admin Modal
-  document.getElementById('createAdminBtn').addEventListener('click', function () {
-    const authMode = _cfg.adminAuthMode;
-    const entraOnly = authMode === 'entra';
-    const entraEnabled = authMode === 'entra' || authMode === 'both';
-    createAdminModalBody.innerHTML = `
-      <form id="createAdminForm" method="POST" action="/create_admin_account">
-        <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
-        ${entraEnabled ? `<div class="alert alert-info d-flex align-items-center gap-2 py-2 mb-3">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>
-          ${entraOnly ? 'This admin will sign in with their Microsoft account. Name will be populated on first login.' : 'This admin can sign in with Microsoft or their local credentials.'}
-        </div>` : ''}
-        ${entraOnly ? '' : `<div class="mb-3">
-          <label for="firstName" class="form-label">First Name</label>
-          <input type="text" class="form-control" id="firstName" name="first_name" required>
-        </div>
-        <div class="mb-3">
-          <label for="lastName" class="form-label">Last Name</label>
-          <input type="text" class="form-control" id="lastName" name="last_name" required>
-        </div>
-        <div class="mb-3">
-          <label for="username" class="form-label">Username</label>
-          <input type="text" class="form-control" id="username" name="username" required>
-        </div>`}
-        <div class="mb-3">
-          <label for="email" class="form-label">Email</label>
-          <input type="email" class="form-control" id="email" name="email" required>
-        </div>
-        <div class="mb-3">
-          <label for="role" class="form-label">Role</label>
-          <select class="form-select" id="role" name="role" required>
-            <option value="manager">Manager</option>
-            <option value="super">Super</option>
-          </select>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-primary">Create</button>
-        </div>
-      </form>
-    `;
-
-    // Show the modal
-    const modalInstance = bootstrap.Modal.getOrCreateInstance(createAdminModal);
-    modalInstance.show();
-  });
-});
-
-
-document.addEventListener('DOMContentLoaded', function () {
-  const editAdminModal = document.getElementById('editAdminModal');
-  const editAdminModalBody = document.getElementById('editAdminModalBody');
-
-  // Attach event listener to all edit buttons
   document.querySelectorAll('.editAdminBtn[data-admin]').forEach(button => {
     button.addEventListener('click', function () {
-      let adminData = this.getAttribute('data-admin'); // Get admin data from the button's data attribute
-      let admin = JSON.parse(adminData); // Parse the JSON data
-      let nameParts = (admin.full_name || '').split(' ').filter(Boolean);
-      let firstName = nameParts[0] || '';
-      let lastName = nameParts.slice(1).join(' ') || '';
-
-      // Populate the modal body with a form
+      const admin     = JSON.parse(this.getAttribute('data-admin'));
+      const nameParts = (admin.full_name || '').split(' ').filter(Boolean);
+      const firstName = nameParts[0] || '';
+      const lastName  = nameParts.slice(1).join(' ') || '';
       editAdminModalBody.innerHTML = `
         <form id="createAdminForm" method="POST" action="/edit_admin_account">
           <input type="hidden" name="user_id" value="${escapeHtml(admin.id)}">
           <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
           <div class="mb-3">
-        <label for="firstName" class="form-label">First Name</label>
-        <input type="text" class="form-control" id="firstName" name="first_name" value="${escapeHtml(firstName)}" required>
+            <label for="firstName" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="firstName" name="first_name" value="${escapeHtml(firstName)}" required>
           </div>
           <div class="mb-3">
-        <label for="lastName" class="form-label">Last Name</label>
-        <input type="text" class="form-control" id="lastName" name="last_name" value="${escapeHtml(lastName)}" required>
+            <label for="lastName" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="lastName" name="last_name" value="${escapeHtml(lastName)}" required>
           </div>
           <div class="mb-3">
-        <label for="username" class="form-label">Username</label>
-        <input type="text" class="form-control" id="username" name="username" value="${escapeHtml(admin.username)}" required>
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" value="${escapeHtml(admin.username)}" required>
           </div>
           <div class="mb-3">
-        <label for="email" class="form-label">Email</label>
-        <input type="email" class="form-control" id="email" name="email" value="${escapeHtml(admin.email)}" required>
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" name="email" value="${escapeHtml(admin.email)}" required>
           </div>
           <div class="mb-3">
-        <label for="role" class="form-label">Role</label>
-        <select class="form-select" id="role" name="role" required>
-          <option value="manager" ${admin.role === 'manager' ? 'selected' : ''}>Manager</option>
-          <option value="super" ${admin.role === 'super' ? 'selected' : ''}>Super</option>
-        </select>
+            <label for="role" class="form-label">Role</label>
+            <select class="form-select" id="role" name="role" required>
+              <option value="manager" ${admin.role === 'manager' ? 'selected' : ''}>Manager</option>
+              <option value="super" ${admin.role === 'super' ? 'selected' : ''}>Super</option>
+            </select>
           </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-primary">Update</button>
-        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Update</button>
+          </div>
         </form>
       `;
-
-      // Show the modal
-      const modalInstance = bootstrap.Modal.getOrCreateInstance(editAdminModal);
-      modalInstance.show();
+      bootstrap.Modal.getOrCreateInstance(editAdminModal).show();
     });
   });
-});
 
+  // ── Delete admin modal ───────────────────────────────────────────────────
 
-document.addEventListener('DOMContentLoaded', function () {
-  const deleteAdminModal = document.getElementById('deleteAdminModal');
-  const deleteAdminModalBody = document.getElementById('deleteAdminModalBody');
-
-  // Attach event listener to all delete buttons
   document.querySelectorAll('.deleteAdminBtn[data-admin]').forEach(button => {
     button.addEventListener('click', function () {
-      let adminData = this.getAttribute('data-admin');
-      let admin = JSON.parse(adminData);
-
-      // Populate the modal body with confirmation message and confirm button
+      const admin = JSON.parse(this.getAttribute('data-admin'));
       deleteAdminModalBody.innerHTML = `
         <p>Are you sure you want to delete admin <strong>${escapeHtml(admin.full_name || admin.username)}</strong>?</p>
         <input type="hidden" id="deleteAdminUserId" value="${escapeHtml(admin.id)}">
@@ -482,87 +348,42 @@ document.addEventListener('DOMContentLoaded', function () {
           <button type="button" class="btn btn-danger" id="confirmDeleteAdminBtn">Yes, Delete</button>
         </div>
       `;
-
-      // Show the modal
       const modalInstance = bootstrap.Modal.getOrCreateInstance(deleteAdminModal);
       modalInstance.show();
+      document.getElementById('confirmDeleteAdminBtn').onclick = function () {
+        const formData = new FormData();
+        formData.append('user_id', document.getElementById('deleteAdminUserId').value);
+        postAction('/delete_admin_account', formData)
+          .then(data => showResultModal(data.success, data.message || (data.success ? 'Admin deleted successfully.' : 'Failed to delete admin.')))
+          .catch(() => showResultModal(false, 'An error occurred while deleting the admin.'))
+          .finally(() => modalInstance.hide());
+      };
+    });
+  });
 
-      // Set up confirm button handler (must re-select since it's re-rendered)
-      const confirmDeleteBtn = document.getElementById('confirmDeleteAdminBtn');
-      confirmDeleteBtn.onclick = function () {
-        const userId = document.getElementById('deleteAdminUserId').value;
+  // ── Delete submission modal ──────────────────────────────────────────────
 
-        fetch('/delete_admin_account', {
-          method: 'POST',
-          headers: { 'X-Requested-With': 'XMLHttpRequest', 'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': csrfToken },
-          body: new URLSearchParams({ user_id: userId })
-        })
-        .then(response => response.json())
-        .then(data => {
-          // Show result modal based on response, using the returned message
-          if (typeof showResultModal === 'function') {
-            showResultModal(data.success, data.message || (data.success ? 'Admin deleted successfully.' : 'Failed to delete admin.'));
-          }
-          modalInstance.hide();
-        })
-        .catch(() => {
-          if (typeof showResultModal === 'function') {
-            showResultModal(false, 'An error occurred while deleting the admin.');
-          }
-          modalInstance.hide();
-        });
+  document.querySelectorAll('.deleteSubmissionBtn[data-request-id]').forEach(button => {
+    button.addEventListener('click', function () {
+      const requestId = this.getAttribute('data-request-id');
+      const name      = this.getAttribute('data-submission');
+      deleteSubmissionModalBody.innerHTML = `
+        <form id="deleteSubmission">
+          <div class="mb-3">
+            <p>Are you sure you would like to delete this submission for <b>${escapeHtml(name)}</b>?</p>
+          </div>
+        </form>
+      `;
+      const modalInstance = bootstrap.Modal.getOrCreateInstance(deleteSubmissionModal);
+      modalInstance.show();
+      document.getElementById('deleteConfirmBtn').onclick = function () {
+        const formData = new FormData();
+        formData.append('request_id', requestId);
+        postAction(deleteUrl, formData)
+          .then(data => showResultModal(data.success, data.message, data.errors || {}))
+          .catch(() => showResultModal(false, 'An error occurred while deleting the submission.'))
+          .finally(() => modalInstance.hide());
       };
     });
   });
 });
-
-
-
-document.addEventListener('DOMContentLoaded', function () {
-  const deleteSubmissionModal = document.getElementById('deleteSubmissionModal');
-  const deleteSubmissionModalBody = document.getElementById('deleteSubmissionModalBody');
-
-  document.querySelectorAll('.deleteSubmissionBtn[data-request-id]').forEach(button => {
-      button.addEventListener('click', function () {
-        const requestId = this.getAttribute('data-request-id');
-
-        
-        const deleteConfirmBtn = document.getElementById('deleteConfirmBtn');
-        let name = this.getAttribute('data-submission');
-
-        deleteSubmissionModalBody.innerHTML = `
-          <form id="deleteSubmission">
-            <div class="mb-3">
-              <p>Are you sure you would like to delete this submission for <b>${escapeHtml(name)}</b>?</p>
-            </div>
-          </form>
-        `;
-
-        // Show the modal
-        const modalInstance = bootstrap.Modal.getOrCreateInstance(deleteSubmissionModal);
-        modalInstance.show();
-
-        // Handle confirmation
-        deleteConfirmBtn.onclick = function () {
-
-          const formData = new FormData();
-          formData.append('request_id', requestId);
-
-          fetch(deleteUrl, {
-            method: 'POST',
-            headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': csrfToken },
-            body: formData
-          })
-            .then(response => response.json())
-            .then(data => {
-              showResultModal(data.success, data.message, data.errors || {});
-              modalInstance.hide(); // Close the modal after submission
-            })
-            .catch(() => {
-              showResultModal(false, 'An error occurred while deleting the submission.');
-              modalInstance.hide(); // Close the modal after submission
-            });
-        };
-      });
-    });
-  });

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'includes/macros.html' import csrf_field %}
 
 {% block title %}Admin Login - {{ SITE_TITLE }} {% endblock %}
 
@@ -17,7 +18,7 @@
 
           {% if admin_auth_mode in ('local', 'both') %}
           <form method="POST" action="{{ url_for('admin.admin') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {{ csrf_field() }}
             <div class="mb-3 text-start">
               <label class="form-label">Username</label>
               <input type="text" class="form-control" id="username"

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'includes/macros.html' import csrf_field %}
+{% from 'includes/macros.html' import csrf_field with context %}
 
 {% block title %}Admin Login - {{ SITE_TITLE }} {% endblock %}
 

--- a/app/templates/admin_forgot_password.html
+++ b/app/templates/admin_forgot_password.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'includes/macros.html' import csrf_field %}
+{% from 'includes/macros.html' import csrf_field with context %}
 
 {% block content %}
 <h3 class="card-title text-center mb-4">Account recovery</h3>

--- a/app/templates/admin_forgot_password.html
+++ b/app/templates/admin_forgot_password.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'includes/macros.html' import csrf_field %}
 
 {% block content %}
 <h3 class="card-title text-center mb-4">Account recovery</h3>
@@ -7,7 +8,7 @@
         <div class="card-body">
             
             <form method="post" action="{{ url_for('admin.forgot_password') }}">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                {{ csrf_field() }}
                 <div class="mb-3">
                     <input type="text" id="identifier" name="identifier" class="form-control" placeholder="Enter your email or username" required>
                 </div>

--- a/app/templates/admin_panel.html
+++ b/app/templates/admin_panel.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 {% import 'includes/macros.html' as macros %}
+{% from 'includes/macros.html' import csrf_field, view_photos_btn %}
 <div class="container py-4">
   <h2 class="text-white mb-4">Admin Panel</h2>
   <ul class="nav nav-pills mb-3" id="admin-tab" role="tablist">
@@ -73,13 +74,7 @@
             <td>{{ req.id_number }}</td>
             <td>{{ req.location }}</td>
             <td>{{ req.timestamp_inserted }}</td>
-            <td>
-              <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#photoModal"
-                data-photo-user="{{ url_for('admin.serve_upload', filename=req.photo_filepath) }}"
-                data-photo-license="{{ url_for('admin.serve_upload', filename=req.license_filepath) }}">
-                View Photos
-              </button>
-            </td>
+            <td>{{ view_photos_btn(req.photo_filepath, req.license_filepath) }}</td>
             <td>
               <button class="btn btn-sm btn-success" data-request-id="{{ req.request_id }}" data-bs-toggle="modal" data-bs-target="#resultModal" data-action="approve">Approve</button>
               <button class="btn btn-sm btn-danger" data-request-id="{{ req.request_id }}" data-bs-toggle="modal" data-bs-target="#rejectModal" data-action="reject">Reject</button>
@@ -116,13 +111,7 @@
             <td>{{ req.id_number }}</td>
             <td>{{ req.location }}</td>
             <td>{{ req.timestamp_inserted }}</td>
-            <td>
-              <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#photoModal"
-                data-photo-user="{{ url_for('admin.serve_upload', filename=req.photo_filepath) }}"
-                data-photo-license="{{ url_for('admin.serve_upload', filename=req.license_filepath) }}">
-                View Photos
-              </button>
-            </td>
+            <td>{{ view_photos_btn(req.photo_filepath, req.license_filepath) }}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -162,13 +151,7 @@
                 View Comments
               </button>
             </td>
-            <td>
-              <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#photoModal"
-                data-photo-user="{{ url_for('admin.serve_upload', filename=req.photo_filepath) }}"
-                data-photo-license="{{ url_for('admin.serve_upload', filename=req.license_filepath) }}">
-                View Photos
-              </button>
-            </td>
+            <td>{{ view_photos_btn(req.photo_filepath, req.license_filepath) }}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -226,7 +209,7 @@
       <div class="card bg-secondary text-white shadow-lg rounded-4 p-4 profile-form">
         <h4 class="mb-3">Edit Account</h4>
         <form method="POST" action="{{ url_for('admin.change_admin_password') }}">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ csrf_field() }}
           <div class="mb-3">
             <label for="username" class="form-label">Username</label>
             <input type="text" class="form-control" id="username" name="username" value="{{ current_user.username }}" disabled>
@@ -261,7 +244,7 @@
      <div class="tab-pane fade {% if active_tab == 'search' %}show active{% endif %}" id="search">
         <h4 class="mb-3">Search submissions</h4>
         <form class="d-flex" role="search" method="POST" action="{{ url_for('admin.search_submissions')}}">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ csrf_field() }}
           <input class="form-control me-2" type="search" placeholder="Search for user submissions" aria-label="Search" name="search_term">
           <button class="btn btn-success" type="submit">Search</button>
         </form>
@@ -288,13 +271,7 @@
             <td>{{ result.id_number }}</td>
             <td>{{ result.location }}</td>
             <td>{{ result.timestamp_inserted }}</td>
-            <td>
-              <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#photoModal"
-                data-photo-user="{{ url_for('admin.serve_upload', filename=result.photo_filepath) }}"
-                data-photo-license="{{ url_for('admin.serve_upload', filename=result.license_filepath) }}">
-                View Photos
-              </button>
-            </td>
+            <td>{{ view_photos_btn(result.photo_filepath, result.license_filepath) }}</td>
             <td>
               <button class="deleteSubmissionBtn btn btn-sm btn-danger" data-request-id="{{ result.request_id }}" data-bs-toggle="modal" data-bs-target="#deleteSubmissionModal" data-action="delete" data-submission="{{ result.first_name }} {{ result.last_name}}">Delete</button>
             </td> 

--- a/app/templates/admin_panel.html
+++ b/app/templates/admin_panel.html
@@ -7,8 +7,8 @@
 {% endblock %}
 
 {% block content %}
-{% import 'includes/macros.html' as macros %}
-{% from 'includes/macros.html' import csrf_field, view_photos_btn %}
+{% import 'includes/macros.html' as macros with context %}
+{% from 'includes/macros.html' import csrf_field, view_photos_btn with context %}
 <div class="container py-4">
   <h2 class="text-white mb-4">Admin Panel</h2>
   <ul class="nav nav-pills mb-3" id="admin-tab" role="tablist">

--- a/app/templates/change_admin_password.html
+++ b/app/templates/change_admin_password.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
+{% from 'includes/macros.html' import csrf_field %}
 
 {% block content %}
 <div class="container mt-5">
     <h2 class="mb-4">Change Password</h2>
     <form method="post" action="{{ url_for('admin.change_admin_password') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {{ csrf_field() }}
         {% if not forgot_password %}
         <div class="mb-3">
             <label for="new_password" class="form-label">Current Password</label>

--- a/app/templates/change_admin_password.html
+++ b/app/templates/change_admin_password.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'includes/macros.html' import csrf_field %}
+{% from 'includes/macros.html' import csrf_field with context %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/includes/macros.html
+++ b/app/templates/includes/macros.html
@@ -1,3 +1,13 @@
+{% macro csrf_field() %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endmacro %}
+
+{% macro view_photos_btn(photo_filepath, license_filepath) %}
+<button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#photoModal"
+  data-photo-user="{{ url_for('admin.serve_upload', filename=photo_filepath) }}"
+  data-photo-license="{{ url_for('admin.serve_upload', filename=license_filepath) }}">
+  View Photos
+</button>
+{% endmacro %}
+
 {% macro modal(id, title, body_id, footer_buttons) %}
 <div class="modal fade" id="{{ id }}" tabindex="-1">
   <div class="modal-dialog">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'includes/macros.html' import csrf_field %}
 
 {% block title %}Log In – {{ SITE_TITLE }}{% endblock %}
 
@@ -16,7 +17,7 @@
 
           {% if user_auth_mode in ('ldap', 'both') %}
           <form method="POST" action="{{ url_for('user.login') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {{ csrf_field() }}
             <div class="mb-3 text-start">
               <label for="email" class="form-label">Email</label>
               <input type="email" class="form-control" id="email"

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'includes/macros.html' import csrf_field %}
+{% from 'includes/macros.html' import csrf_field with context %}
 
 {% block title %}Log In – {{ SITE_TITLE }}{% endblock %}
 

--- a/app/templates/upload_photo.html
+++ b/app/templates/upload_photo.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'includes/macros.html' import csrf_field %}
+{% from 'includes/macros.html' import csrf_field with context %}
 {% block title %}Upload Your Photo{% endblock %}
 
 {% block head %}

--- a/app/templates/upload_photo.html
+++ b/app/templates/upload_photo.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'includes/macros.html' import csrf_field %}
 {% block title %}Upload Your Photo{% endblock %}
 
 {% block head %}
@@ -17,7 +18,7 @@
         <form method="POST"
               action="{{ url_for('user.upload_photo') }}"
               enctype="multipart/form-data">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ csrf_field() }}
           <!-- ID Photo input -->
           <div class="mb-3">
             <label for="idPhotoUpload" class="form-label">


### PR DESCRIPTION
## Summary

- **Backend:** Extract shared helpers (`_set_admin_session`, `_fetch_admin_password`, `_send`, `_validate_admin_form`, `_parse_user_id`, `_json`, `UtilityHelper.paginate`) to remove ~15 duplicated code blocks across `auth_service.py`, `email_service.py`, `admin_routes.py`, `admin_service.py`, and `submission_service.py`
- **Frontend:** Merge 10 separate `DOMContentLoaded` listeners into one; extract `postAction()` fetch helper (6 call sites), `buildRejectForm()` for duplicate textarea HTML, replace `.then`+`.catch` modal hide with `.finally()`; merge duplicate select-all listeners. Also fixes a latent bug where `rejectModal`/`rejectModalBody`/`rejectConfirmBtn` were undefined in the bulk-reject handler
- **Templates:** Add `csrf_field()` and `view_photos_btn()` Jinja2 macros; replace 7 hardcoded CSRF inputs and 4 duplicate View Photos button blocks across 6 templates

Net result: −270 lines across 14 files. All 181 unit tests pass.

## Test plan

- [x] `docker exec flask_test python -m pytest tests/ -v` → 181/181 passed
- [x] Flask container healthy after rebuild (`docker ps` confirms)
- [x] Verified `csrf_field()` macro works with `with context` import (fixes `UndefinedError: 'csrf_token' is undefined` that surfaced after initial push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)