### PR TITLE
fix: resolve security and bug findings from code audit

### DIFF
--- a/app/helpers/decorator_helper.py
+++ b/app/helpers/decorator_helper.py
@@ -34,6 +34,6 @@ class DecoratorHelper:
         def decorated(*args, **kwargs):
             if session.get("on_login") == 1:
                 flash("Please change your password first!", "danger")
-                return redirect(url_for("admin.admin"))
+                return redirect(url_for("admin.change_admin_password"))
             return f(*args, **kwargs)
         return decorated

--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -114,7 +114,7 @@ def create_admin_account():
         flash("Failed to create admin account. Please check logs for more details", "danger")
     return redirect(url_for("admin.admin_panel", active_tab="admins"))
 
-@admin_blueprint.route("/logout")
+@admin_blueprint.route("/logout", methods=["POST"])
 def logout():
     user_type = 0
     if "admin_username" in session:

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -43,7 +43,7 @@ def landing():
 def upload_form():
     return render_template("upload_photo.html")
     
-@user_blueprint.route("/upload_photo", methods = ["GET", "POST"])
+@user_blueprint.route("/upload_photo", methods=["POST"])
 @DecoratorHelper.check_login
 def upload_photo():
     submission_service = current_app.submission_service
@@ -61,7 +61,6 @@ def upload_photo():
             pfn = UtilityHelper.generate_unique_filename(photo.filename)
             lfn = UtilityHelper.generate_unique_filename(drivers_license.filename)
 
-
             photo.save(os.path.join(current_app.config["UPLOAD_FOLDER"], pfn))
             drivers_license.save(os.path.join(current_app.config["UPLOAD_FOLDER"], lfn))
 
@@ -69,7 +68,6 @@ def upload_photo():
                 flash("Documents uploaded successfully!", "success")
                 flash("You will receive an email once your ID is ready!", "success")
                 email_service.send_email_alert()
-                return redirect(url_for("admin.logout"))
             else:
                 for fp in (pfn, lfn):
                     try:
@@ -77,4 +75,7 @@ def upload_photo():
                     except OSError:
                         pass
                 flash("An error has occurred, please try again later", "danger")
-                return redirect(url_for("admin.logout"))
+    flashes = session.get('_flashes', [])
+    session.clear()
+    session['_flashes'] = flashes
+    return redirect(url_for("user.home"))

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -160,6 +160,9 @@ class AuthService:
 
     def entra_user_login(self, userinfo: dict) -> bool:
         email = userinfo.get('email') or userinfo.get('preferred_username', '')
+        if not email:
+            self.logger.warning("Entra user login rejected: no email in userinfo")
+            return False
         given_name  = userinfo.get('given_name', '')
         family_name = userinfo.get('family_name', '')
         attrs = {
@@ -167,6 +170,8 @@ class AuthService:
             'Last Name':  family_name,
             'Email':      email,
             'cn':         userinfo.get('preferred_username', email),
+            'ID Number':  '',
+            'Location':   '',
         }
         self.logger.info(f"Entra user login for: {email}")
         return self.set_session_attrs(attrs)

--- a/app/services/ldap_service.py
+++ b/app/services/ldap_service.py
@@ -67,6 +67,8 @@ class LDAPService:
             if not dn:
                 return None, None, False
 
+            if not password:
+                return None, None, False
             conn = None
             try:
                 conn = ldap.initialize(self.ldap_server)

--- a/app/templates/admin_panel.html
+++ b/app/templates/admin_panel.html
@@ -33,7 +33,10 @@
       <a class="nav-link {% if active_tab == 'search' %}active{% endif %}" href="{{ url_for('admin.admin_panel', active_tab='search') }}">Search</a>
     </li>
     <li class="nav-item">
-      <a href="/logout" class="btn btn-danger" role="button">Log out</a>
+      <form method="POST" action="/logout" class="d-inline">
+        {{ csrf_field() }}
+        <button type="submit" class="btn btn-danger">Log out</button>
+      </form>
     </li>
   </ul>
 

--- a/app/tests/test_admin_routes.py
+++ b/app/tests/test_admin_routes.py
@@ -122,15 +122,20 @@ def test_get_admin_panel_search_no_results(app, admin_client):
 # ── POST /logout ──────────────────────────────────────────────────────────────
 
 def test_logout_admin_clears_session(admin_client):
-    resp = admin_client.get('/logout')
+    resp = admin_client.post('/logout')
     assert resp.status_code == 302
     assert '/admin' in resp.headers['Location']
+
+
+def test_logout_get_not_allowed(client):
+    resp = client.get('/logout')
+    assert resp.status_code == 405
 
 
 def test_logout_user_redirects_home(client):
     with client.session_transaction() as sess:
         sess['user_logged_in'] = True
-    resp = client.get('/logout')
+    resp = client.post('/logout')
     assert resp.status_code == 302
 
 

--- a/app/tests/test_auth_service.py
+++ b/app/tests/test_auth_service.py
@@ -243,6 +243,20 @@ def test_entra_user_login_sets_session(app, svc):
     assert result is True
 
 
+def test_entra_user_login_includes_id_number_and_location(app, svc):
+    userinfo = {'email': 'u@example.com', 'given_name': 'Jane', 'family_name': 'Doe'}
+    with app.test_request_context('/'):
+        svc.entra_user_login(userinfo)
+        assert session.get('ID Number') == ''
+        assert session.get('Location') == ''
+
+
+def test_entra_user_login_empty_email_rejected(app, svc):
+    with app.test_request_context('/'):
+        result = svc.entra_user_login({})
+    assert result is False
+
+
 # ── check_bfa ────────────────────────────────────────────────────────────────
 
 def test_check_bfa_no_record_success_allowed(svc, db):

--- a/app/tests/test_decorator_helper.py
+++ b/app/tests/test_decorator_helper.py
@@ -110,4 +110,4 @@ def test_check_first_login_redirects_when_on_login_one(client):
         sess['on_login'] = 1
     resp = client.get('/first-login-check')
     assert resp.status_code == 302
-    assert '/admin-login' in resp.headers['Location']
+    assert '/change_admin_password' in resp.headers['Location']

--- a/app/tests/test_ldap_service.py
+++ b/app/tests/test_ldap_service.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from flask import Flask
+from services.ldap_service import LDAPService
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config.update({
+        'TESTING': True,
+        'SECRET_KEY': 'ldap-test',
+        'LDAP_URI': 'ldap://localhost',
+        'LDAP_BIND_DN': 'cn=svc,dc=example,dc=com',
+        'LDAP_BIND_PWD': 'svcpass',
+        'LDAP_SEARCH_BASE': 'dc=example,dc=com',
+        'LDAP_SEARCH_FILTER': '(mail={0})',
+        'LDAP_ATTRIBUTES': '{"First Name": "givenName", "Last Name": "sn", "Email": "mail", "ID Number": "employeeNumber", "Location": "l", "cn": "cn"}',
+        'LDAP_USE_TLS': False,
+        'LDAP_TLS_CACERTFILE': None,
+    })
+    return a
+
+
+@pytest.fixture
+def auth_svc():
+    return MagicMock()
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(app, auth_svc, db):
+    return LDAPService(auth_service=auth_svc, app=app, db=db)
+
+
+# ── auth_user ────────────────────────────────────────────────────────────────
+
+def test_auth_user_empty_password_rejected(app, svc, auth_svc, db):
+    auth_svc.check_bfa.return_value = True
+    db.execute_query.return_value = (0,)  # no pending submissions
+    with patch.object(svc, 'search_user', return_value=('cn=user,dc=example,dc=com', {'Email': 'u@x.com'})), \
+         patch.object(svc, 'check_user_submissions', return_value=True):
+        with app.test_request_context('/'):
+            msg, attrs, result = svc.auth_user('u@x.com', '')
+    assert result is False
+    assert attrs is None
+
+
+def test_auth_user_none_password_rejected(app, svc, auth_svc):
+    auth_svc.check_bfa.return_value = True
+    with patch.object(svc, 'search_user', return_value=('cn=user,dc=example,dc=com', {'Email': 'u@x.com'})), \
+         patch.object(svc, 'check_user_submissions', return_value=True):
+        with app.test_request_context('/'):
+            msg, attrs, result = svc.auth_user('u@x.com', None)
+    assert result is False
+    assert attrs is None
+
+
+def test_auth_user_bfa_blocked_returns_false(app, svc, auth_svc):
+    auth_svc.check_bfa.return_value = False
+    with app.test_request_context('/'):
+        msg, attrs, result = svc.auth_user('u@x.com', 'somepass')
+    assert result is False
+
+
+def test_auth_user_pending_submission_blocked(app, svc, auth_svc):
+    auth_svc.check_bfa.return_value = True
+    with patch.object(svc, 'check_user_submissions', return_value=False):
+        with app.test_request_context('/'):
+            msg, attrs, result = svc.auth_user('u@x.com', 'somepass')
+    assert result is False
+    assert 'pending' in msg.lower() or 'approved' in msg.lower()
+
+
+def test_auth_user_user_not_found_returns_false(app, svc, auth_svc):
+    auth_svc.check_bfa.return_value = True
+    with patch.object(svc, 'check_user_submissions', return_value=True), \
+         patch.object(svc, 'search_user', return_value=(None, {})):
+        with app.test_request_context('/'):
+            msg, attrs, result = svc.auth_user('u@x.com', 'somepass')
+    assert result is False

--- a/app/tests/test_user_routes.py
+++ b/app/tests/test_user_routes.py
@@ -126,6 +126,11 @@ def _make_upload(filename, content):
     return (io.BytesIO(content), filename)
 
 
+def test_upload_photo_get_not_allowed(client):
+    resp = client.get('/upload_photo')
+    assert resp.status_code == 405
+
+
 def test_upload_photo_requires_login(client):
     resp = client.post('/upload_photo')
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary

- **LDAP anonymous bind** — reject empty/None passwords before `simple_bind_s`; servers that allow anonymous bind would otherwise grant access to any user who submits a blank password
- **Entra user login** — guard against empty email (returns `False` early) and add `'ID Number'` / `'Location'` to session attrs so `upload_photo` never throws a `KeyError` crash
- **`check_first_login` redirect** — decorator was sending first-login admins to the login page instead of the change-password page, making the forced password change unreachable
- **`/logout` CSRF** — changed to POST-only and updated the nav link to a `<form>` with CSRF token, preventing force-logout attacks via GET
- **`/upload_photo` GET crash** — removed GET from the route (was falling through with no return → 500); replaced `redirect(admin.logout)` calls with inline session clearing

## Test plan

- [ ] 190 tests pass (`pytest tests/ -v`) — up from 181; 9 new tests added
- [ ] `test_ldap_service.py` — new file: empty/None password rejected, BFA block, pending submission block, user not found
- [ ] `test_auth_service.py` — two new entra_user_login tests: empty email rejected, ID Number/Location in session
- [ ] `test_user_routes.py` — new: GET /upload_photo returns 405
- [ ] `test_admin_routes.py` — logout tests updated to POST; new test: GET /logout returns 405
- [ ] `test_decorator_helper.py` — first-login redirect now asserts `/change_admin_password`

🤖 Generated with [Claude Code](https://claude.com/claude-code)